### PR TITLE
feat: 이미지 카드 컴포넌트 생성

### DIFF
--- a/components/ui/ImageCard.stories.tsx
+++ b/components/ui/ImageCard.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Card, CardDescription } from './ImageCard';
+
+const meta: Meta<typeof Card> = {
+  title: 'Components/ui/ImageCard',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    size: {
+      defaultValue: 'md',
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'inline-radio' },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  args: {
+    size: 'md',
+  },
+  render: (args) => (
+    <Card size={args.size} src="https://picsum.photos/200/300">
+      <CardDescription>
+        Card Footer Card Footer Card FooterCard Footer Card Footer
+      </CardDescription>
+    </Card>
+  ),
+};

--- a/components/ui/ImageCard.stories.tsx
+++ b/components/ui/ImageCard.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof ImageCard> = {
 
 export default meta;
 
-type Story = StoryObj<typeof ImageCard>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {

--- a/components/ui/ImageCard.stories.tsx
+++ b/components/ui/ImageCard.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Card, CardDescription } from './ImageCard';
+import { ImageCard, ImageCardDescription } from './ImageCard';
 
-const meta: Meta<typeof Card> = {
+const meta: Meta<typeof ImageCard> = {
   title: 'Components/ui/ImageCard',
-  component: Card,
+  component: ImageCard,
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
@@ -19,17 +19,17 @@ const meta: Meta<typeof Card> = {
 
 export default meta;
 
-type Story = StoryObj<typeof Card>;
+type Story = StoryObj<typeof ImageCard>;
 
 export const Default: Story = {
   args: {
     size: 'md',
   },
   render: (args) => (
-    <Card size={args.size} src="https://picsum.photos/200/300">
-      <CardDescription>
+    <ImageCard size={args.size} src="https://picsum.photos/200/300">
+      <ImageCardDescription>
         Card Footer Card Footer Card FooterCard Footer Card Footer
-      </CardDescription>
-    </Card>
+      </ImageCardDescription>
+    </ImageCard>
   ),
 };

--- a/components/ui/ImageCard.tsx
+++ b/components/ui/ImageCard.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+import Image from './Image';
+import Text from './Text';
+
+interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: 'sm' | 'md' | 'lg';
+  src: string;
+}
+
+interface CardImageContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  src: string;
+  size?: { width: number; height: number };
+}
+
+interface CardDescriptionContentProps
+  extends React.HTMLAttributes<HTMLSpanElement> {}
+
+const CardImage = React.forwardRef<HTMLDivElement, CardImageContentProps>(
+  ({ className, src, size = { width: 240, height: 240 }, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('pb-2 flex justify-center', className)}
+        {...props}
+      >
+        <Image
+          src={src}
+          alt="card image"
+          width={size.width}
+          height={size.height}
+        />
+      </div>
+    );
+  },
+);
+CardImage.displayName = 'CardImage';
+
+function CardDescription({ children }: CardDescriptionContentProps) {
+  return (
+    <div className="w-full">
+      <Text lineClamp={1}>{children}</Text>
+    </div>
+  );
+}
+CardDescription.displayName = 'CardDescription';
+
+const Card = React.forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, src, size = 'md', children, ...props }, ref) => {
+    const sizeClasses = {
+      sm: 'w-44 ', // small size
+      md: 'w-64 ', // medium size (default)
+      lg: 'w-80 ', // large size
+    };
+
+    // Card 크기에 맞게 이미지의 크기 조정
+    const cardSizes = {
+      sm: { width: 160 - 12, height: 160 - 12 }, // 패딩을 고려하여 크기 조정
+      md: { width: 240 - 12, height: 240 - 12 }, // 패딩을 고려하여 크기 조정
+      lg: { width: 320 - 12, height: 320 - 12 }, // 패딩을 고려하여 크기 조정
+    };
+
+    const paddingClasses = {
+      sm: 'p-3',
+      md: 'p-4',
+      lg: 'p-6',
+    };
+
+    const paddingBClasses = {
+      sm: 'pb-1',
+      md: 'pb-3',
+      lg: 'pb-5',
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'rounded-lg border bg-card text-card-foreground shadow-sm cursor-pointer', // 패딩 추가
+          sizeClasses[size],
+          className,
+        )}
+        {...props}
+      >
+        <div className={cn('flex-col', paddingClasses[size])}>
+          <CardImage
+            src={src}
+            size={cardSizes[size]}
+            className={paddingBClasses[size]}
+          />
+          {children}
+        </div>
+      </div>
+    );
+  },
+);
+
+Card.displayName = 'Card';
+
+export { Card, CardImage, CardDescription };

--- a/components/ui/ImageCard.tsx
+++ b/components/ui/ImageCard.tsx
@@ -18,7 +18,7 @@ interface CardImageContentProps extends React.HTMLAttributes<HTMLDivElement> {
 interface CardDescriptionContentProps
   extends React.HTMLAttributes<HTMLSpanElement> {}
 
-const CardImage = React.forwardRef<HTMLDivElement, CardImageContentProps>(
+const ImageCardImage = React.forwardRef<HTMLDivElement, CardImageContentProps>(
   ({ className, src, size = { width: 240, height: 240 }, ...props }, ref) => {
     return (
       <div
@@ -36,18 +36,18 @@ const CardImage = React.forwardRef<HTMLDivElement, CardImageContentProps>(
     );
   },
 );
-CardImage.displayName = 'CardImage';
+ImageCardImage.displayName = 'ImageCardImage';
 
-function CardDescription({ children }: CardDescriptionContentProps) {
+function ImageCardDescription({ children }: CardDescriptionContentProps) {
   return (
     <div className="w-full">
       <Text lineClamp={1}>{children}</Text>
     </div>
   );
 }
-CardDescription.displayName = 'CardDescription';
+ImageCardDescription.displayName = 'ImageCardDescription';
 
-const Card = React.forwardRef<HTMLDivElement, CardContentProps>(
+const ImageCard = React.forwardRef<HTMLDivElement, CardContentProps>(
   ({ className, src, size = 'md', children, ...props }, ref) => {
     const sizeClasses = {
       sm: 'w-44 ', // small size
@@ -85,7 +85,7 @@ const Card = React.forwardRef<HTMLDivElement, CardContentProps>(
         {...props}
       >
         <div className={cn('flex-col', paddingClasses[size])}>
-          <CardImage
+          <ImageCardImage
             src={src}
             size={cardSizes[size]}
             className={paddingBClasses[size]}
@@ -97,6 +97,6 @@ const Card = React.forwardRef<HTMLDivElement, CardContentProps>(
   },
 );
 
-Card.displayName = 'Card';
+ImageCard.displayName = 'ImageCard';
 
-export { Card, CardImage, CardDescription };
+export { ImageCard, ImageCardImage, ImageCardDescription };

--- a/components/ui/ImageCard.tsx
+++ b/components/ui/ImageCard.tsx
@@ -18,7 +18,7 @@ interface CardImageContentProps extends React.HTMLAttributes<HTMLDivElement> {
 interface CardDescriptionContentProps
   extends React.HTMLAttributes<HTMLSpanElement> {}
 
-const ImageCardImage = React.forwardRef<HTMLDivElement, CardImageContentProps>(
+const ImageCardCover = React.forwardRef<HTMLDivElement, CardImageContentProps>(
   ({ className, src, size = { width: 240, height: 240 }, ...props }, ref) => {
     return (
       <div
@@ -36,7 +36,7 @@ const ImageCardImage = React.forwardRef<HTMLDivElement, CardImageContentProps>(
     );
   },
 );
-ImageCardImage.displayName = 'ImageCardImage';
+ImageCardCover.displayName = 'ImageCardCover';
 
 function ImageCardDescription({ children }: CardDescriptionContentProps) {
   return (
@@ -85,7 +85,7 @@ const ImageCard = React.forwardRef<HTMLDivElement, CardContentProps>(
         {...props}
       >
         <div className={cn('flex-col', paddingClasses[size])}>
-          <ImageCardImage
+          <ImageCardCover
             src={src}
             size={cardSizes[size]}
             className={paddingBClasses[size]}
@@ -99,4 +99,4 @@ const ImageCard = React.forwardRef<HTMLDivElement, CardContentProps>(
 
 ImageCard.displayName = 'ImageCard';
 
-export { ImageCard, ImageCardImage, ImageCardDescription };
+export { ImageCard, ImageCardCover, ImageCardDescription };


### PR DESCRIPTION
- Close #12 

## What is this PR? 🔍

- 기능 : 이미지 카드 컴포넌트를 생성하였습니다. 
- issue : #12

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 이미지 카드 컴포넌트를 크기별로 구현하였습니다. 
- size 속성에 sm, md, lg 를 부여하면 크기별 렌더링이 가능합니다. 
- 이미지 카드는 이미지가 필수입니다. src 속성에 이미지 주소를 넣어야 합니다. 
- ImageCardDescription은 설명이 필요한 경우에만 추가하면 됩니다. 
## ScreenShot 📷
![image](https://github.com/user-attachments/assets/55ed2076-74d3-45f7-b404-1b391cab0a65)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
- ImageCardDescription 의 Text 에는 lineClamp={1} 속성이 static 하게 지정되어 있습니다. 해당 속성은 1줄이 넘어가면 말줄임표를 사용해달라는 속성입니다. 기획 상 이미지 카드에 1줄 이상인 설명이 필요하지 않을 것 같아 우선 이렇게 지정하였으나, 추후 기획이 변경이 필요하다면  수정하도록 하겠습니다. 
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
