### PR TITLE
refactor: Input 컴포넌트 search, icon props 추가

### DIFF
--- a/components/ui/Input.stories.tsx
+++ b/components/ui/Input.stories.tsx
@@ -33,18 +33,19 @@ function UserIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
+      width="24"
+      height="24"
       viewBox="0 0 24 24"
       fill="none"
       stroke="gray"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
-      className="lucide lucide-search"
+      className="lucide lucide-badge-alert"
     >
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
+      <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
+      <line x1="12" x2="12" y1="8" y2="12" />
+      <line x1="12" x2="12.01" y1="16" y2="16" />
     </svg>
   );
 }
@@ -56,10 +57,18 @@ export const Default: Story = {
   },
 };
 
-export const Search: Story = {
+export const Icon: Story = {
   args: {
     size: 'md',
     radius: 'md',
     icon: <UserIcon />,
+  },
+};
+
+export const Search: Story = {
+  args: {
+    size: 'md',
+    radius: 'md',
+    search: true,
   },
 };

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -22,10 +22,12 @@ const inputVariants = cva('', {
     radius: 'md',
   },
 });
+
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
     VariantProps<typeof inputVariants> {
   icon?: React.ReactNode;
+  search?: boolean;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -37,6 +39,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       type,
       placeholder = 'placeholder',
       icon,
+      search,
       ...props
     },
     ref,
@@ -52,7 +55,26 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <span className={cn('inset-y-0 left-0 flex items-center')}>
             {icon}
           </span>
-        )}{' '}
+        )}
+        {search && (
+          <span className={cn('inset-y-0 left-0 flex items-center')}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="gray"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className="lucide lucide-search"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </span>
+        )}
         <input
           placeholder={placeholder}
           type={type}


### PR DESCRIPTION
- Close #16

## What is this PR? 🔍

- 기능 : Input 컴포넌트 search, icon props 추가했습니다. 
- issue : #16 

## Changes 📝
- icon이 있는 input을 사용하고 싶은 경우, icon이 있는 컴포넌트를 Input의 icon 속성으로 넘겨주면 됩니다. 
- search input을 사용하고 싶은 경우, Input의 search 속성만 true로 주면 됩니다. 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
<img width="718" alt="image" src="https://github.com/user-attachments/assets/b51e542d-150e-4012-8439-4f0d3f93bb37">
<img width="718" alt="image" src="https://github.com/user-attachments/assets/09baf797-adc9-4184-adeb-cbd4f1a0ba22">

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
