### PR TITLE
feat: 헤더 컴포넌트 생성

### DIFF
--- a/components/ui/Header.stories.tsx
+++ b/components/ui/Header.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Header from './Header';
+
+const meta: Meta<typeof Header> = {
+  title: 'Components/ui/Header',
+  component: Header,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    isLogin: { control: 'boolean' },
+    isJoined: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const LoggedOut: Story = {
+  args: {
+    isLogin: false,
+    isJoined: false,
+  },
+};
+
+export const LoggedInNotJoined: Story = {
+  args: {
+    isLogin: true,
+    isJoined: false,
+  },
+};
+
+export const LoggedInJoined: Story = {
+  args: {
+    isLogin: true,
+    isJoined: true,
+  },
+};

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { UserRound } from 'lucide-react';
+import { UserStateProps } from '@/types/layoutTypes';
+import { Input } from './Input';
+import { LinkText } from './Text';
+
+const personalSection = (isLogin: boolean, isJoined: boolean) => {
+  if (!isLogin) {
+    return (
+      <div className="flex w-44 justify-evenly">
+        <LinkText
+          color="gray"
+          className="text-sm cursor-pointer text-center leading-6 font-normal"
+          link="/"
+        >
+          동호회 새로 만들기
+        </LinkText>
+        <LinkText
+          color="primary"
+          className="text-sm cursor-pointer leading-6"
+          link="/"
+        >
+          Login
+        </LinkText>
+      </div>
+    );
+  }
+  if (!isJoined) {
+    return (
+      <div className="flex w-40 justify-evenly">
+        <LinkText
+          color="gray"
+          className="text-sm cursor-pointer text-center leading-6 font-normal"
+          link="/"
+        >
+          동호회 새로 만들기
+        </LinkText>
+        <UserRound
+          size={24}
+          className="text-black cursor-pointer group-hover:text-white transition-colors"
+        />
+      </div>
+    );
+  }
+  return (
+    // return <LucideIcon color={color} size={size} />;
+    <UserRound size={24} cursor-pointer color="#000000" />
+  );
+};
+
+function Header(props: UserStateProps) {
+  const { isLogin, isJoined } = props;
+  return (
+    <div className="flex items-center justify-between space-x-4 w-full max-w-5xl h-16 px-8 border-solid border-b border-gray-200">
+      <div className="text-xl font-semibold cursor-pointer">LOGO</div>
+
+      <div className="flex items-center justify-end space-x-2 w-1/2">
+        <div className="w-1/2">
+          <Input search radius="round" placeholder="" size="sm" />
+        </div>
+        {personalSection(isLogin, isJoined)}
+      </div>
+    </div>
+  );
+}
+
+export default Header;

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -51,7 +51,7 @@ const personalSection = (isLogin: boolean, isJoined: boolean) => {
 function Header(props: UserStateProps) {
   const { isLogin, isJoined } = props;
   return (
-    <div className="flex items-center justify-between space-x-4 w-full max-w-5xl h-16 px-8 border-solid border-b border-gray-200">
+    <div className="flex items-center justify-between space-x-4 w-full max-w-5xl h-16 px-8 sticky top-0 z-50 border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="text-xl font-semibold cursor-pointer">LOGO</div>
 
       <div className="flex items-center justify-end space-x-2 w-1/2">

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -51,7 +51,7 @@ const personalSection = (isLogin: boolean, isJoined: boolean) => {
 function Header(props: UserStateProps) {
   const { isLogin, isJoined } = props;
   return (
-    <div className="flex items-center justify-between space-x-4 w-full max-w-5xl h-16 px-8 sticky top-0 z-50 border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <div className="flex items-center justify-between space-x-4 w-full max-w-5xl h-16 sticky top-0 z-50 border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="text-xl font-semibold cursor-pointer">LOGO</div>
 
       <div className="flex items-center justify-end space-x-2 w-1/2">

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -10,14 +10,17 @@ const personalSection = (isLogin: boolean, isJoined: boolean) => {
       <div className="flex w-44 justify-evenly">
         <LinkText
           color="gray"
-          className="text-sm cursor-pointer text-center leading-6 font-normal"
+          size="sm"
+          align="center"
+          className="cursor-pointer leading-6"
           link="/"
         >
           동호회 새로 만들기
         </LinkText>
         <LinkText
           color="primary"
-          className="text-sm cursor-pointer leading-6"
+          size="sm"
+          className="cursor-pointer leading-6"
           link="/"
         >
           Login
@@ -30,7 +33,9 @@ const personalSection = (isLogin: boolean, isJoined: boolean) => {
       <div className="flex w-40 justify-evenly">
         <LinkText
           color="gray"
-          className="text-sm cursor-pointer text-center leading-6 font-normal"
+          size="sm"
+          align="center"
+          className=" cursor-pointer leading-6"
           link="/"
         >
           동호회 새로 만들기
@@ -42,10 +47,7 @@ const personalSection = (isLogin: boolean, isJoined: boolean) => {
       </div>
     );
   }
-  return (
-    // return <LucideIcon color={color} size={size} />;
-    <UserRound size={24} cursor-pointer color="#000000" />
-  );
+  return <UserRound size={24} cursor-pointer color="#000000" />;
 };
 
 function Header(props: UserStateProps) {

--- a/components/ui/ImageCard.tsx
+++ b/components/ui/ImageCard.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 import Image from './Image';
-import Text from './Text';
+import { Text } from './Text';
 
 interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: 'sm' | 'md' | 'lg';

--- a/components/ui/Input.stories.tsx
+++ b/components/ui/Input.stories.tsx
@@ -38,9 +38,9 @@ function UserIcon() {
       viewBox="0 0 24 24"
       fill="none"
       stroke="gray"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       className="lucide lucide-badge-alert"
     >
       <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />

--- a/components/ui/Input.stories.tsx
+++ b/components/ui/Input.stories.tsx
@@ -33,18 +33,19 @@ function UserIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
+      width="24"
+      height="24"
       viewBox="0 0 24 24"
       fill="none"
       stroke="gray"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
-      className="lucide lucide-search"
+      className="lucide lucide-badge-alert"
     >
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
+      <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
+      <line x1="12" x2="12" y1="8" y2="12" />
+      <line x1="12" x2="12.01" y1="16" y2="16" />
     </svg>
   );
 }
@@ -56,10 +57,18 @@ export const Default: Story = {
   },
 };
 
-export const Search: Story = {
+export const Icon: Story = {
   args: {
     size: 'md',
     radius: 'md',
     icon: <UserIcon />,
+  },
+};
+
+export const Search: Story = {
+  args: {
+    size: 'md',
+    radius: 'md',
+    search: true,
   },
 };

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -60,14 +60,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <span className={cn('inset-y-0 left-0 flex items-center')}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
+              width="20"
+              height="20"
               viewBox="0 0 24 24"
               fill="none"
               stroke="gray"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
               className="lucide lucide-search"
             >
               <circle cx="11" cy="11" r="8" />

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -22,10 +22,12 @@ const inputVariants = cva('', {
     radius: 'md',
   },
 });
+
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
     VariantProps<typeof inputVariants> {
   icon?: React.ReactNode;
+  search?: boolean;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -37,6 +39,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       type,
       placeholder = 'placeholder',
       icon,
+      search,
       ...props
     },
     ref,
@@ -52,7 +55,26 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <span className={cn('inset-y-0 left-0 flex items-center')}>
             {icon}
           </span>
-        )}{' '}
+        )}
+        {search && (
+          <span className={cn('inset-y-0 left-0 flex items-center')}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="gray"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className="lucide lucide-search"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </span>
+        )}
         <input
           placeholder={placeholder}
           type={type}

--- a/components/ui/Text.stories.tsx
+++ b/components/ui/Text.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import Text from './Text';
+import { Text } from './Text';
 
 const meta: Meta<typeof Text> = {
   title: 'Components/ui/Text',

--- a/components/ui/Text.tsx
+++ b/components/ui/Text.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
 import React from 'react';
 
 interface TextProps {
@@ -11,6 +13,11 @@ interface TextProps {
   lineClamp?: number;
   color?: 'primary' | 'black' | 'gray' | 'white';
   inherit?: boolean;
+  className?: string;
+}
+
+interface LinkProps extends TextProps {
+  link: string;
 }
 
 function Text({
@@ -24,6 +31,7 @@ function Text({
   lineClamp,
   color = 'black',
   inherit = false,
+  className = '',
 }: TextProps): JSX.Element {
   // 말줄임 설정 위한 코드
   let displayStyle: string = 'inline';
@@ -71,11 +79,79 @@ function Text({
   return (
     <span
       style={{ ...baseStyles }}
-      className={[colorClass, sizeClass, weightClass].join(' ')}
+      className={cn([colorClass, sizeClass, weightClass].join(' '), className)}
     >
       {children}
     </span>
   );
 }
 
-export default Text;
+function LinkText({
+  children,
+  size = 'md',
+  weight = 'regular',
+  underline = false,
+  block = false,
+  transform,
+  align,
+  lineClamp,
+  color = 'black',
+  inherit = false,
+  link = '',
+  className = '',
+}: LinkProps): JSX.Element {
+  // 말줄임 설정 위한 코드
+  let displayStyle: string = 'inline';
+  if (lineClamp) {
+    displayStyle = '-webkit-box';
+  } else if (block) {
+    displayStyle = 'block';
+  }
+
+  const colorClass =
+    {
+      primary: 'text-primary', // #007BFF
+      black: 'text-black',
+      gray: 'text-gray-500',
+      white: 'text-white',
+    }[color] || 'text-black'; // 기본값
+
+  const sizeClass =
+    {
+      xs: 'text-xs',
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-xl',
+      xl: 'text-2xl',
+    }[size] || 'text-base';
+
+  const weightClass =
+    {
+      light: 'font-extralight',
+      regular: 'font-medium',
+      bold: 'font-extrabold',
+    }[weight] || 'regular';
+
+  const baseStyles: React.CSSProperties = {
+    display: displayStyle,
+    textDecoration: underline ? 'underline' : 'none',
+    textTransform: transform,
+    textAlign: align,
+    color: inherit ? 'inherit' : color || 'black',
+    WebkitLineClamp: lineClamp,
+    overflow: lineClamp ? 'hidden' : 'visible',
+    WebkitBoxOrient: lineClamp ? 'vertical' : undefined,
+  };
+
+  return (
+    <Link
+      style={{ ...baseStyles }}
+      className={cn([colorClass, sizeClass, weightClass].join(' '), className)}
+      href={link}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export { Text, LinkText };

--- a/types/layoutTypes.ts
+++ b/types/layoutTypes.ts
@@ -1,0 +1,4 @@
+export interface UserStateProps {
+  isLogin: boolean;
+  isJoined: boolean;
+}


### PR DESCRIPTION
- Close #10 

## What is this PR? 🔍

- 기능 : 유저 상태에 따른 헤더를 구현하였습니다.  
- issue : #10 

## Changes 📝
- Text 컴포넌트에 LinkText 컴포넌트를 추가하여 이동할 수 있는 텍스트 컴포넌트를 생성하였습니다. 
- Text 컴포넌트에 class를 추가할 수 있도록 변경하였습니다. 
- Input의 Search Input 아이콘의 크기를 변경하였습니다. 

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
- 비로그인
![image](https://github.com/user-attachments/assets/779763ee-3ceb-41a3-90f9-27e345408855)

- 로그인 && 동호회 미가입
![image](https://github.com/user-attachments/assets/362cd514-c938-4ee0-a5c7-d9eada9c3575)

 - 로그인 && 동호회 가입
![image](https://github.com/user-attachments/assets/07a792bb-a893-4dee-8fb5-cfd524e3068b)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
- 로고와 프로필 사진은 추후 변경 필요합니다 .
- 디폴트 프로필 사진은 어떻게 할지 논의가 필요합니다. 
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
