### PR TITLE
feat: 멤버 페이지 생성

### DIFF
--- a/app/(header)/club/member/MemberDropdown.tsx
+++ b/app/(header)/club/member/MemberDropdown.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+function MemberDropDown() {
+  return (
+    <div className="absolute top-12 right-0 mt-2 w-24 bg-white border border-gray-400 rounded-md shadow-lg z-50">
+      <ul className="py-2">
+        <li className="px-4 py-2 text-gray-400 hover:bg-gray-100 cursor-pointer">
+          역할 변경
+        </li>
+        <li className="px-4 py-2 text-gray-400 hover:bg-gray-100 cursor-pointer">
+          정지
+        </li>
+        <li className="px-4 py-2 text-red-400 hover:bg-gray-100 cursor-pointer">
+          탈퇴
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default MemberDropDown;

--- a/app/(header)/club/member/OneMemberInfo.tsx
+++ b/app/(header)/club/member/OneMemberInfo.tsx
@@ -2,7 +2,7 @@
 
 import IconButton from '@/components/ui/IconButton';
 import { AlignJustify } from 'lucide-react';
-import React, { useState } from 'react';
+import React from 'react';
 import MemberDropDown from './MemberDropdown';
 
 interface OneMemberInfoProps {

--- a/app/(header)/club/member/OneMemberInfo.tsx
+++ b/app/(header)/club/member/OneMemberInfo.tsx
@@ -1,8 +1,16 @@
+'use client';
+
 import IconButton from '@/components/ui/IconButton';
 import { AlignJustify } from 'lucide-react';
-import React from 'react';
+import React, { useState } from 'react';
+import MemberDropDown from './MemberDropdown';
 
-function OneMemberInfo() {
+interface OneMemberInfoProps {
+  isOpen: boolean; // 드롭다운 상태
+  onToggle: () => void; // 드롭다운 토글 함수
+}
+
+function OneMemberInfo({ isOpen, onToggle }: OneMemberInfoProps) {
   return (
     <div className="flex justify-center space-x-40">
       <div className="flex items-center gap-8">
@@ -18,11 +26,12 @@ function OneMemberInfo() {
         </div>
         <p className="text-gray-400">멤버 이름</p>
       </div>
-      <div className="flex items-center gap-8">
+      <div className="flex items-center gap-8 relative">
         <p className="text-gray-400">00전 | 00승 | 00무 | 00패</p>
-        <IconButton size="sm" color="transparent">
+        <IconButton size="sm" color="transparent" onClick={onToggle}>
           <AlignJustify width="80%" height="80%" className="text-gray-400" />
         </IconButton>
+        {isOpen && <MemberDropDown />}
       </div>
     </div>
   );

--- a/app/(header)/club/member/OneMemberInfo.tsx
+++ b/app/(header)/club/member/OneMemberInfo.tsx
@@ -1,0 +1,31 @@
+import IconButton from '@/components/ui/IconButton';
+import { AlignJustify } from 'lucide-react';
+import React from 'react';
+
+function OneMemberInfo() {
+  return (
+    <div className="flex justify-center space-x-40">
+      <div className="flex items-center gap-8">
+        <div className="w-20 h-20">
+          <img
+            src="/images/dummy-image.jpg"
+            alt="member_image"
+            className=" object-cover w-full h-full rounded-full"
+          />
+        </div>
+        <div className="w-8 h-8">
+          <img src="/images/tier-gold.png" alt="member_tier" />
+        </div>
+        <p className="text-gray-400">멤버 이름</p>
+      </div>
+      <div className="flex items-center gap-8">
+        <p className="text-gray-400">00전 | 00승 | 00무 | 00패</p>
+        <IconButton size="sm" color="transparent">
+          <AlignJustify width="80%" height="80%" className="text-gray-400" />
+        </IconButton>
+      </div>
+    </div>
+  );
+}
+
+export default OneMemberInfo;

--- a/app/(header)/club/member/page.tsx
+++ b/app/(header)/club/member/page.tsx
@@ -1,12 +1,26 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import OneMemberInfo from './OneMemberInfo';
 
 function ClubMemberPage() {
+  const [openDropdownIndex, setOpenDropdownIndex] = useState<number | null>(
+    null,
+  );
+
+  const toggleDropdown = (index: number) => {
+    setOpenDropdownIndex((prevIndex) => (prevIndex === index ? null : index));
+  };
+
   return (
     <div className="h-[466px]">
       <div className="flex flex-col gap-4 h-full overflow-scroll">
-        {Array.from({ length: 30 }).map(() => (
-          <OneMemberInfo key="id" />
+        {Array.from({ length: 30 }, (_, index) => (
+          <OneMemberInfo
+            key={index}
+            isOpen={openDropdownIndex === index}
+            onToggle={() => toggleDropdown(index)}
+          />
         ))}
       </div>
     </div>

--- a/app/(header)/club/member/page.tsx
+++ b/app/(header)/club/member/page.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import OneMemberInfo from './OneMemberInfo';
 
 function ClubMemberPage() {
-  return <div>member</div>;
+  return (
+    <div className="h-[466px]">
+      <div className="flex flex-col gap-4 h-full overflow-scroll">
+        {Array.from({ length: 30 }).map(() => (
+          <OneMemberInfo key="id" />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default ClubMemberPage;

--- a/components/ui/IconButton.tsx
+++ b/components/ui/IconButton.tsx
@@ -6,6 +6,7 @@ interface IconButtonProps {
   radius?: 'sm' | 'md' | 'lg' | 'round';
   color?: 'gray' | 'primary' | 'transparent';
   outline?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 function IconButton(props: IconButtonProps) {
@@ -15,6 +16,7 @@ function IconButton(props: IconButtonProps) {
     radius = 'md',
     color = 'gray',
     outline = false,
+    onClick,
   } = props;
 
   const sizeClass =
@@ -47,6 +49,7 @@ function IconButton(props: IconButtonProps) {
     <button
       type="button"
       className={`flex justify-center items-center ${outlineClass} ${sizeClass} ${radiusClass} ${colorClass} hover:filter hover:brightness-90`}
+      onClick={onClick}
     >
       <div className="w-full h-full flex justify-center items-center">
         {children}


### PR DESCRIPTION
- Close #41 

## What is this PR? 🔍

- 기능 : 멤버 페이지를 생성하였습니다. 
- issue : #41 

## Changes 📝
- 멤버들의 이미지, 티어, 이름, 전적, 관리 버튼을 구현 하였습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fd2834c1-abd0-4f14-a76d-7753342f17fa">

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
- 스크롤을 통해 멤버들을 쭉 확인 할 수 있도록 구현하였습니다.
- 햄버거 버튼 클릭 시 멤버를 관리할 수 있는 dropdown을 만들었습니다. 다만 내부 div의 height를 지정해 준 상태이기 때문에  맨 아래 멤버의 햄버거 버튼 클릭 시 스크롤을 통해서 dropdown을 확인 할 수 있습니다.
- 우선 API 연동이 안되어 있는 부분이기 때문에 p태그를 이용해 내용을 채워줬습니다. 추후 티어에 따른 이미지를 넣어주는 로직과 정보를 받아오는 로직을 추가 구현해야 합니다.
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
