### PR TITLE
fix: 새로고침 했을 때 url 에 따라 탭 활성화되도록 수정

### DIFF
--- a/app/(header)/club/layout.tsx
+++ b/app/(header)/club/layout.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import Link from 'next/link';
+import { headers } from 'next/headers';
 
 function ClubLayout({ children }: { children: React.ReactNode }) {
+  const headerList = headers();
+  const pathname = headerList.get('x-current-path')?.split('/')[2];
+
   return (
-    <Tabs defaultValue="intro" className="w-full max-w-5xl mt-10 ">
+    <Tabs defaultValue={pathname} className="w-full max-w-5xl mt-10 ">
       <TabsList>
         <Link href="/club/intro">
           <TabsTrigger value="intro" color="gray">

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  // Add a new header x-current-path which passes the path to downstream components
+  const headers = new Headers(request.headers);
+  headers.set('x-current-path', request.nextUrl.pathname);
+  return NextResponse.next({ headers });
+}
+
+export const config = {
+  matcher: [
+    // match all routes except static files and APIs
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+  ],
+};


### PR DESCRIPTION
- Close #38

## What is this PR? 🔍

- 기능 : 새로고침 했을 때 탭 활성화 되지 않는 오류 해결하였습니다. 
- issue : #38 

## Changes 📝
- middleware 파일 생성하여 files 와 APIs 가 아닌 파일에 한해 url을 응답 헤더에 set 해주었습니다. 
- layout에서는 아래 사진과 같이 header에서 x-current-path 가져 와서 현재 url을 가져올 수 있습니다. 이렇게 가져온 url은 /club/intro 처럼 / 로 시작합니다. 
  
![image](https://github.com/user-attachments/assets/3348b915-1c87-4140-b1f2-af90b7a6720c)

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
![Sep-30-2024 17-06-12](https://github.com/user-attachments/assets/67f2c143-69f9-4c9a-8949-036d52bc0e5a)

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
