### PR TITLE
feat: 마이 페이지 생성

### DIFF
--- a/app/(header)/my/MyOneGameResult.tsx
+++ b/app/(header)/my/MyOneGameResult.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function MyOneGameResult() {
+  return (
+    <div className="flex justify-between border-2 border-gray-400 p-4 rounded-md">
+      <p className="text-lg font-bold">vs 경기 상대</p>
+      <p className="text-lg font-bold">승</p>
+      <p>00월 00일</p>
+    </div>
+  );
+}
+
+export default MyOneGameResult;

--- a/app/(header)/my/page.tsx
+++ b/app/(header)/my/page.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/ui/Button';
+import React from 'react';
+import MyOneGameResult from './MyOneGameResult';
+
+function My() {
+  return (
+    <div className="mt-8 px-16 py-8 border-2 border-gray-400 rounded-md">
+      <div className="flex justify-evenly">
+        <img
+          src="/images/dummy-image.jpg"
+          alt="userImg"
+          className="w-64 h64 rounded-full"
+        />
+        <div className="flex flex-col w-1/4 gap-8">
+          <div className="flex justify-between items-center gap-4">
+            <p className="font-bold text-lg">유저이름</p>
+            <Button>수정</Button>
+          </div>
+          <div className="flex justify-between items-center gap-4">
+            <p className="font-bold text-lg">소속 동호회 이름</p>
+            <Button>탈퇴</Button>
+          </div>
+          <div className="flex items-center gap-4">
+            <p className="font-bold text-lg">티어</p>
+            <img
+              src="/images/tier-gold.png"
+              alt="userTier"
+              className="w-8 h-8"
+            />
+          </div>
+          <div className="flex gap-4">
+            <p className="font-bold text-lg">전적</p>
+            <p>00전 | 00승 | 00무 | 00패</p>
+          </div>
+        </div>
+      </div>
+      <div className="w-full mt-8">
+        <p className="font-bold text-xl">경기 결과</p>
+        <div className="flex flex-col mt-2 w-full h-64 overflow-scroll px-8 py-4 border-2 border-gray-400 rounded-md gap-4">
+          {Array.from({ length: 30 }, (_, index) => (
+            <MyOneGameResult key={index} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default My;


### PR DESCRIPTION
- Close #48 

## What is this PR? 🔍

- 기능 : 마이 페이지를 생성하였습니다.
- issue : #48 

## Changes 📝
- 마이페이지에 필요한 사용자 정보와 해당 사용자의 경기 결과 UI를 구현하였습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/00f87d3c-66de-404f-bd7f-f62e39d0ae2e">

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements
- 기존 와이어프레임에서 헤더가 생긴 점을 생각하여 마이페이지도 새로운 페이지에서 만들어 주었습니다.
- 유저 정보를 수정하는 페이지에 대한 논의가 필요할 것 같습니다.
- 경기 결과에서 와이어프레임 때 구상하였던 승과 패에 따른 백그라운드 색상을 다르게 하는 것은 한번 더 이야기 후에 API 통신에서 구현하도록 해야할 것 같습니다.
- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
