### PR TITLE
feat: 대진표 화면 및 기능 구현

### DIFF
--- a/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileDoubles.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileDoubles.tsx
@@ -1,6 +1,6 @@
 import MatchScoreModalDoubles from "./MatchScoreModalDoubles";
 
-interface DoublesProps {
+interface MatchProfileDoublesProps {
   team1: {
     participant1_name: string;
     participant1_image: string;
@@ -17,7 +17,12 @@ interface DoublesProps {
   onClose: () => void;
 }
 
-function MatchProfileSingles({ team1, team2, isOpen, onClose }: DoublesProps) {
+function MatchProfileDoubles({
+  team1,
+  team2,
+  isOpen,
+  onClose,
+}: MatchProfileDoublesProps) {
   return (
     <div className="flex">
       <div className="flex rounded-md bg-gray-200 items-center w-[450px] p-2 justify-between">
@@ -70,4 +75,4 @@ function MatchProfileSingles({ team1, team2, isOpen, onClose }: DoublesProps) {
     </div>
   );
 }
-export default MatchProfileSingles;
+export default MatchProfileDoubles;

--- a/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileDoubles.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileDoubles.tsx
@@ -1,0 +1,73 @@
+import MatchScoreModalDoubles from "./MatchScoreModalDoubles";
+
+interface DoublesProps {
+  team1: {
+    participant1_name: string;
+    participant1_image: string;
+    participant2_name: string;
+    participant2_image: string;
+  };
+  team2: {
+    participant1_name: string;
+    participant1_image: string;
+    participant2_name: string;
+    participant2_image: string;
+  };
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function MatchProfileSingles({ team1, team2, isOpen, onClose }: DoublesProps) {
+  return (
+    <div className="flex">
+      <div className="flex rounded-md bg-gray-200 items-center w-[450px] p-2 justify-between">
+        <div className="flex gap-2">
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={team1.participant1_image}
+              alt="user"
+              className="h-20 w-20 rounded-full"
+            />
+            <p className="text-black">{team1.participant1_name}</p>
+          </div>
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={team1.participant2_image}
+              alt="user"
+              className="h-20 w-20 rounded-full"
+            />
+            <p className="text-black">{team1.participant2_name}</p>
+          </div>
+        </div>
+        <p className="text-black text-xl font-bold">1 vs 1</p>
+        <div className="flex gap-2">
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={team2.participant1_image}
+              alt="user"
+              className="h-20 w-20 rounded-full"
+            />
+            <p className="text-black">{team2.participant1_name}</p>
+          </div>
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={team2.participant2_image}
+              alt="user"
+              className="h-20 w-20 rounded-full"
+            />
+            <p className="text-black">{team2.participant2_name}</p>
+          </div>
+        </div>
+      </div>
+      {isOpen && (
+        <MatchScoreModalDoubles
+          isOpen={isOpen}
+          team1={team1}
+          team2={team2}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+export default MatchProfileSingles;

--- a/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileSingles.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileSingles.tsx
@@ -1,0 +1,57 @@
+import MatchScoreModalSingles from "./MatchScoreModalSingles";
+
+interface SinglesProps {
+  singlesMatch: {
+    participant1_name: string;
+    participant1_image: string;
+    participant2_name: string;
+    participant2_image: string;
+  };
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function MatchProfileSingles({ singlesMatch, isOpen, onClose }: SinglesProps) {
+  const {
+    participant1_name,
+    participant1_image,
+    participant2_name,
+    participant2_image,
+  } = singlesMatch;
+
+  return (
+    <div className="flex">
+      <div className="flex rounded-md bg-gray-200 items-center w-72 p-2 justify-between">
+        <div className="flex flex-col items-center gap-4">
+          <img
+            src={participant1_image}
+            alt="user"
+            className="h-20 w-20 rounded-full"
+          />
+          <p className="text-black">{participant1_name}</p>
+        </div>
+        <div className="flex flex-col items-center">
+          <p className="text-sm text-black">진행 완료</p>
+          <p className="text-black text-2xl font-bold">2 vs 0</p>
+        </div>
+        <div className="flex flex-col items-center gap-4">
+          <img
+            src={participant2_image}
+            alt="user"
+            className="h-20 w-20 rounded-full"
+          />
+          <p className="text-black">{participant2_name}</p>
+        </div>
+      </div>
+      {isOpen && (
+        <MatchScoreModalSingles
+          isOpen={isOpen}
+          singlesMatch={singlesMatch}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+
+export default MatchProfileSingles;

--- a/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileSingles.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/MatchProfileSingles.tsx
@@ -1,6 +1,6 @@
 import MatchScoreModalSingles from "./MatchScoreModalSingles";
 
-interface SinglesProps {
+interface MatchProfileSinglesProps {
   singlesMatch: {
     participant1_name: string;
     participant1_image: string;
@@ -11,7 +11,11 @@ interface SinglesProps {
   onClose: () => void;
 }
 
-function MatchProfileSingles({ singlesMatch, isOpen, onClose }: SinglesProps) {
+function MatchProfileSingles({
+  singlesMatch,
+  isOpen,
+  onClose,
+}: MatchProfileSinglesProps) {
   const {
     participant1_name,
     participant1_image,

--- a/app/(header)/my-club/schedule/[leagueId]/match/MatchScoreModalDoubles.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/MatchScoreModalDoubles.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useState } from "react";
+
+interface MatchScoreModalDoublesProps {
+  team1: {
+    participant1_name: string;
+    participant1_image: string;
+    participant2_name: string;
+    participant2_image: string;
+  };
+  team2: {
+    participant1_name: string;
+    participant1_image: string;
+    participant2_name: string;
+    participant2_image: string;
+  };
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function MatchScoreModalDoubles({
+  team1,
+  team2,
+  isOpen,
+  onClose,
+}: MatchScoreModalDoublesProps) {
+  const [team1Score, setTeam1Score] = useState<number[]>([0, 0, 0]);
+  const [team2Score, setTeam2Score] = useState<number[]>([0, 0, 0]);
+  const [team1SetScore, setTeam1SetScore] = useState<number>(0);
+  const [team2SetScore, setTeam2SetScore] = useState<number>(0);
+  const [currentSet, setCurrentSet] = useState(0);
+
+  const handleScorePlus = (team: number) => {
+    if (team === 1) {
+      setTeam1Score((prevTeam1Score) => {
+        const newTeam1Score = [...prevTeam1Score];
+
+        if (newTeam1Score[currentSet] === undefined) {
+          newTeam1Score[currentSet] = 0;
+        }
+
+        newTeam1Score[currentSet]++;
+
+        return newTeam1Score;
+      });
+    } else {
+      setTeam2Score((prevTeam2Score) => {
+        const newTeam2Score = [...prevTeam2Score];
+
+        if (newTeam2Score[currentSet] === undefined) {
+          newTeam2Score[currentSet] = 0;
+        }
+
+        newTeam2Score[currentSet]++;
+
+        return newTeam2Score;
+      });
+    }
+  };
+
+  const handleScoreMinus = (team: number) => {
+    if (team === 1) {
+      setTeam1Score((prevTeam1Score) => {
+        const newTeam1Score = [...prevTeam1Score];
+
+        if (newTeam1Score[currentSet] === undefined) {
+          newTeam1Score[currentSet] = 0;
+        }
+
+        if (newTeam1Score[currentSet] > 0) {
+          newTeam1Score[currentSet]--;
+        }
+
+        return newTeam1Score;
+      });
+    } else {
+      setTeam2Score((prevTeam2Score) => {
+        const newTeam2Score = [...prevTeam2Score];
+
+        if (newTeam2Score[currentSet] === undefined) {
+          newTeam2Score[currentSet] = 0;
+        }
+
+        if (newTeam2Score[currentSet] > 0) {
+          newTeam2Score[currentSet]--;
+        }
+
+        return newTeam2Score;
+      });
+    }
+  };
+
+  const handleCurrentSet = () => {
+    if (team1Score[currentSet] === undefined) {
+      team1Score[currentSet] = 0;
+    }
+    if (team2Score[currentSet] === undefined) {
+      team2Score[currentSet] = 0;
+    }
+
+    if (team1Score[currentSet] > team2Score[currentSet]) {
+      setTeam1SetScore(team1SetScore + 1);
+    } else if (team2Score[currentSet] > team1Score[currentSet]) {
+      setTeam2SetScore(team2SetScore + 1);
+    }
+
+    setCurrentSet(currentSet + 1);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className="text-black max-w-[750px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DialogHeader className="w-full">
+          <DialogTitle className="flex justify-center">경기 상세</DialogTitle>
+          <div className="flex w-full justify-between items-center">
+            <div className="flex gap-4">
+              <div className="flex flex-col items-center gap-4">
+                <img
+                  src={team1.participant1_image}
+                  alt="user"
+                  className="h-20 w-20 rounded-full"
+                />
+                <p className="text-black">{team1.participant1_name}</p>
+              </div>
+              <div className="flex flex-col items-center gap-4">
+                <img
+                  src={team1.participant2_image}
+                  alt="user"
+                  className="h-20 w-20 rounded-full"
+                />
+                <p className="text-black">{team1.participant2_name}</p>
+              </div>
+            </div>
+            <p className="text-3xl font-bold">{team1SetScore}</p>
+            <div className="flex flex-col gap-5">
+              {[0, 1, 2].map((setIndex) => (
+                <div key={setIndex}>
+                  {setIndex === currentSet ? (
+                    <div className="flex flex-col items-center mb-4">
+                      <div className="relative flex w-full justify-center">
+                        <p className="flex items-center text-lg font-bold">
+                          세트 {setIndex + 1}
+                        </p>
+                        <button
+                          type="button"
+                          className="absolute right-0 top-1 text-sm"
+                          onClick={handleCurrentSet}
+                        >
+                          완료
+                        </button>
+                      </div>
+                      <div className="flex gap-4">
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleScoreMinus(1)}
+                          >
+                            -
+                          </button>
+                          <p>{team1Score[setIndex]}</p>
+                          <button
+                            type="button"
+                            onClick={() => handleScorePlus(1)}
+                          >
+                            +
+                          </button>
+                        </div>
+                        <p>:</p>
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleScoreMinus(2)}
+                          >
+                            -
+                          </button>
+                          <p>{team2Score[setIndex]}</p>
+                          <button
+                            type="button"
+                            onClick={() => handleScorePlus(2)}
+                          >
+                            +
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col items-center mb-4">
+                      <p className="flex items-center text-lg font-bold">
+                        세트 {setIndex + 1}
+                      </p>
+                      <p className="text-gray-500 text-sm">
+                        {team1Score[setIndex]} : {team2Score[setIndex]}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <p className="text-3xl font-bold">{team2SetScore}</p>
+            <div className="flex gap-4">
+              <div className="flex flex-col items-center gap-4">
+                <img
+                  src={team2.participant1_image}
+                  alt="user"
+                  className="h-20 w-20 rounded-full"
+                />
+                <p className="text-black">{team2.participant1_name}</p>
+              </div>
+              <div className="flex flex-col items-center gap-4">
+                <img
+                  src={team2.participant2_image}
+                  alt="user"
+                  className="h-20 w-20 rounded-full"
+                />
+                <p className="text-black">{team2.participant2_name}</p>
+              </div>
+            </div>
+          </div>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default MatchScoreModalDoubles;

--- a/app/(header)/my-club/schedule/[leagueId]/match/MatchScoreModalSingles.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/MatchScoreModalSingles.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type React from "react";
+import { useState } from "react";
+
+interface MatchScoreModalSinglesProps {
+  singlesMatch: {
+    participant1_name: string;
+    participant1_image: string;
+    participant2_name: string;
+    participant2_image: string;
+  };
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function MatchScoreModalSIngles({
+  isOpen,
+  singlesMatch,
+  onClose,
+}: MatchScoreModalSinglesProps) {
+  const {
+    participant1_name,
+    participant1_image,
+    participant2_name,
+    participant2_image,
+  } = singlesMatch;
+
+  const [p1Score, setP1Score] = useState<number[]>([0, 0, 0]);
+  const [p2Score, setP2Score] = useState<number[]>([0, 0, 0]);
+  const [p1SetScore, setP1SetScore] = useState<number>(0);
+  const [p2SetScore, setP2SetScore] = useState<number>(0);
+  const [currentSet, setCurrentSet] = useState(0);
+
+  const handleScorePlus = (player: number) => {
+    if (player === 1) {
+      setP1Score((prevP1Score) => {
+        const newP1Score = [...prevP1Score];
+
+        if (newP1Score[currentSet] === undefined) {
+          newP1Score[currentSet] = 0;
+        }
+
+        newP1Score[currentSet]++;
+
+        return newP1Score;
+      });
+    } else {
+      setP2Score((prevP2Score) => {
+        const newP2Score = [...prevP2Score];
+
+        if (newP2Score[currentSet] === undefined) {
+          newP2Score[currentSet] = 0;
+        }
+
+        newP2Score[currentSet]++;
+
+        return newP2Score;
+      });
+    }
+  };
+
+  const handleScoreMinus = (player: number) => {
+    if (player === 1) {
+      setP1Score((prevP1Score) => {
+        const newP1Score = [...prevP1Score];
+
+        if (newP1Score[currentSet] === undefined) {
+          newP1Score[currentSet] = 0;
+        }
+
+        if (newP1Score[currentSet] > 0) {
+          newP1Score[currentSet]--;
+        }
+
+        return newP1Score;
+      });
+    } else {
+      setP2Score((prevP2Score) => {
+        const newP2Score = [...prevP2Score];
+
+        if (newP2Score[currentSet] === undefined) {
+          newP2Score[currentSet] = 0;
+        }
+        if (newP2Score[currentSet] > 0) {
+          newP2Score[currentSet]--;
+        }
+
+        return newP2Score;
+      });
+    }
+  };
+
+  const handleCurrentSet = () => {
+    if (p1Score[currentSet] === undefined) {
+      p1Score[currentSet] = 0;
+    }
+    if (p2Score[currentSet] === undefined) {
+      p2Score[currentSet] = 0;
+    }
+
+    if (p1Score[currentSet] > p2Score[currentSet]) {
+      setP1SetScore(p1SetScore + 1);
+    } else if (p2Score[currentSet] > p1Score[currentSet]) {
+      setP2SetScore(p2SetScore + 1);
+    }
+
+    setCurrentSet(currentSet + 1);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className="text-black"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DialogHeader className="w-full">
+          <DialogTitle className="flex justify-center">경기 상세</DialogTitle>
+        </DialogHeader>
+        <div className="flex w-full justify-between items-center">
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={participant1_image}
+              alt="user"
+              className="h-20 w-20 rounded-full"
+            />
+            <p className="text-black">{participant1_name}</p>
+          </div>
+          <p className="text-3xl font-bold">{p1SetScore}</p>
+          <div className="flex flex-col gap-5">
+            {[0, 1, 2].map((setIndex) => (
+              <div key={setIndex}>
+                {setIndex === currentSet ? (
+                  <div className="flex flex-col items-center mb-4">
+                    <div className="relative flex w-full justify-center">
+                      <p className="flex items-center text-lg font-bold">
+                        세트 {setIndex + 1}
+                      </p>
+                      <button
+                        type="button"
+                        className="absolute right-0 top-1 text-sm"
+                        onClick={handleCurrentSet}
+                      >
+                        완료
+                      </button>
+                    </div>
+                    <div className="flex gap-4">
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleScoreMinus(1)}
+                        >
+                          -
+                        </button>
+                        <p>{p1Score[setIndex]}</p>
+                        <button
+                          type="button"
+                          onClick={() => handleScorePlus(1)}
+                        >
+                          +
+                        </button>
+                      </div>
+                      <p>:</p>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleScoreMinus(2)}
+                        >
+                          -
+                        </button>
+                        <p>{p2Score[setIndex]}</p>
+                        <button
+                          type="button"
+                          onClick={() => handleScorePlus(2)}
+                        >
+                          +
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center mb-4">
+                    <p className="flex items-center text-lg font-bold">
+                      세트 {setIndex + 1}
+                    </p>
+                    <p className="text-gray-500 text-sm">
+                      {p1Score[setIndex]} : {p2Score[setIndex]}
+                    </p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+          <p className="text-3xl font-bold">{p2SetScore}</p>
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={participant2_image}
+              alt="user"
+              className="h-20 w-20 rounded-full"
+            />
+            <p className="text-black">{participant2_name}</p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default MatchScoreModalSIngles;

--- a/app/(header)/my-club/schedule/[leagueId]/match/page.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/match/page.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { useState } from "react";
+import MatchProfileDoubles from "./MatchProfileDoubles";
+import MatchProfileSingles from "./MatchProfileSingles";
+
+const matches = [
+  {
+    id: 1,
+    matchType: "SINGLES",
+    singlesMatch: {
+      participant1_name: "name1",
+      participant1_image: "/images/dummy-image.jpg",
+      participant2_name: "name2",
+      participant2_image: "/images/dummy-image.jpg",
+    },
+  },
+  {
+    id: 2,
+    matchType: "SINGLES",
+    singlesMatch: {
+      participant1_name: "name3",
+      participant1_image: "/images/dummy-image.jpg",
+      participant2_name: "name4",
+      participant2_image: "/images/dummy-image.jpg",
+    },
+  },
+  {
+    id: 3,
+    matchType: "SINGLES",
+    singlesMatch: {
+      participant1_name: "name5",
+      participant1_image: "/images/dummy-image.jpg",
+      participant2_name: "name6",
+      participant2_image: "/images/dummy-image.jpg",
+    },
+  },
+  {
+    id: 4,
+    matchType: "SINGLES",
+    singlesMatch: {
+      participant1_name: "name7",
+      participant1_image: "/images/dummy-image.jpg",
+      participant2_name: "name8",
+      participant2_image: "/images/dummy-image.jpg",
+    },
+  },
+  {
+    id: 5,
+    matchType: "SINGLES",
+    singlesMatch: {
+      participant1_name: "name9",
+      participant1_image: "/images/dummy-image.jpg",
+      participant2_name: "name10",
+      participant2_image: "/images/dummy-image.jpg",
+    },
+  },
+  {
+    id: 6,
+    matchType: "DOUBLES",
+    doublesMatch: {
+      team1: {
+        participant1_name: "name1",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name2",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+      team2: {
+        participant1_name: "name3",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name4",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+    },
+  },
+  {
+    id: 7,
+    matchType: "DOUBLES",
+    doublesMatch: {
+      team1: {
+        participant1_name: "name1",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name2",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+      team2: {
+        participant1_name: "name3",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name4",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+    },
+  },
+  {
+    id: 8,
+    matchType: "DOUBLES",
+    doublesMatch: {
+      team1: {
+        participant1_name: "name1",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name2",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+      team2: {
+        participant1_name: "name3",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name4",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+    },
+  },
+  {
+    id: 9,
+    matchType: "DOUBLES",
+    doublesMatch: {
+      team1: {
+        participant1_name: "name1",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name2",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+      team2: {
+        participant1_name: "name3",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name4",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+    },
+  },
+  {
+    id: 10,
+    matchType: "DOUBLES",
+    doublesMatch: {
+      team1: {
+        participant1_name: "name1",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name2",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+      team2: {
+        participant1_name: "name3",
+        participant1_image: "/images/dummy-image.jpg",
+        participant2_name: "name4",
+        participant2_image: "/images/dummy-image.jpg",
+      },
+    },
+  },
+];
+
+function MatchPage() {
+  const [matchTypes, setMatchTypes] = useState(true);
+  const [matchDialog, setMatchDialog] = useState<number | null>(null);
+
+  const toggleMatchDialog = (index: number) => {
+    setMatchDialog((prevIndex) => (prevIndex === index ? null : index));
+  };
+
+  const handleMatchTypeSingles = () => {
+    setMatchTypes(true);
+  };
+
+  const handleMatchTypeDoubles = () => {
+    setMatchTypes(false);
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2">
+        <Button
+          className="rounded-full h-2 py-4"
+          onClick={handleMatchTypeSingles}
+        >
+          단식
+        </Button>
+        <Button
+          className="rounded-full h-2 py-4"
+          onClick={handleMatchTypeDoubles}
+        >
+          복식
+        </Button>
+      </div>
+      {matchTypes ? (
+        <div className="flex gap-10 w-full flex-wrap mt-5">
+          {matches
+            .filter((match) => match.matchType === "SINGLES")
+            .map((match) =>
+              match.singlesMatch ? (
+                <button
+                  type="button"
+                  key={match.id}
+                  onClick={() => toggleMatchDialog(match.id)}
+                >
+                  <MatchProfileSingles
+                    singlesMatch={match.singlesMatch}
+                    isOpen={matchDialog === match.id}
+                    onClose={() => toggleMatchDialog(match.id)}
+                  />
+                </button>
+              ) : null,
+            )}
+        </div>
+      ) : (
+        <div className="flex gap-10 w-full flex-wrap mt-5">
+          {matches
+            .filter((match) => match.matchType === "DOUBLES")
+            .map((match) =>
+              match.doublesMatch ? (
+                <button
+                  type="button"
+                  key={match.id}
+                  onClick={() => toggleMatchDialog(match.id)}
+                >
+                  <MatchProfileDoubles
+                    key={match.id}
+                    team1={match.doublesMatch.team1}
+                    team2={match.doublesMatch.team2}
+                    isOpen={matchDialog === match.id}
+                    onClose={() => toggleMatchDialog(match.id)}
+                  />
+                </button>
+              ) : null,
+            )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MatchPage;

--- a/app/(header)/my-club/schedule/[leagueId]/page.tsx
+++ b/app/(header)/my-club/schedule/[leagueId]/page.tsx
@@ -17,6 +17,7 @@ import {
   User,
   Users,
 } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 
 interface League {
@@ -170,14 +171,16 @@ function LeaguePage() {
         </div>
       </div>
       <div className="flex justify-center items-center pt-8 gap-4">
-        <Button
-          size="lg"
-          variant="outline"
-          className="items-center justify-center gap-2 border-primary w-1/4"
-        >
-          <BookUser size={20} />
-          대진표 보기
-        </Button>
+        <Link className="w-1/4" href={"/my-club/schedule/1/match"}>
+          <Button
+            size="lg"
+            variant="outline"
+            className="items-center justify-center gap-2 border-primary w-full"
+          >
+            <BookUser size={20} />
+            대진표 보기
+          </Button>
+        </Link>
         <Button
           size="lg"
           variant={isParticipant ? "destructive" : "default"}


### PR DESCRIPTION
- Close #111 

## What is this PR? 🔍

- 기능 : 대진표 화면 및 기능 구현
- issue : #111

## Changes 📝
- 단식/복식 나눠서 경기 상대 및 진행상황, 현재 세트 스코어가 보이도록 하였습니다.
- 하나의 경기를 누르게 되면 경기 상세 페이지로 넘어가 세트별 점수를 조절할 수 있고, 점수 입력이 완료되면 이긴 사람의 세트 스코어가 오르도록 구현하였습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
https://github.com/user-attachments/assets/6ff19c63-a325-4972-9d66-7643a4113ecf


<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
- 현재 게임 생성 후 진행 상황, 세트 스코어에 대한 기능은 구현되어 있지 않은 상태입니다. API 연동을 하며 수정이 필요합니다.
- 경기 상세 모달에서 세트 점수에 대한 수정은 구현되어 있지 않습니다. 추후 구현이 필요합니다.
- UI가 제대로 구현되어 있지 않습니다. 추후 이야기를 통해 변경이 필요합니다.
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
