### PR TITLE
feat: 멤버 페이지 API 연동

### DIFF
--- a/app/(header)/my-club/member/MemberInfo.tsx
+++ b/app/(header)/my-club/member/MemberInfo.tsx
@@ -30,7 +30,7 @@ function MemberInfo({
   const { win_count, lose_count, draw_count, match_count, tier } =
     leagueRecordInfoResponse;
 
-  const changeRollWord = (roll: string) => {
+  const changeRoleWord = (roll: string) => {
     switch (roll) {
       case "ROLE_OWNER":
         return "회장";
@@ -50,7 +50,7 @@ function MemberInfo({
         <p className="text-black">{name}</p>
       </div>
       <div className="flex flex-[1] items-center">
-        <p className="text-black">{changeRollWord(role)}</p>
+        <p className="text-black">{changeRoleWord(role)}</p>
       </div>
       <div className="flex flex-[1] items-center">
         <p className="text-black">{getTierWithEmoji(tier as string)}</p>

--- a/app/(header)/my-club/member/MemberInfo.tsx
+++ b/app/(header)/my-club/member/MemberInfo.tsx
@@ -1,18 +1,14 @@
 "use client";
 
 import IconButton from "@/components/ui/IconButton";
+import type { components } from "@/schemas/schema";
 import { getTierWithEmoji } from "@/utils/getTierWithEmoji";
 import { AlignJustify } from "lucide-react";
 import React from "react";
 import MemberDropDown from "./MemberDropdown";
 
-interface LeagueRecordInfoResponse {
-  winCount: number;
-  loseCount: number;
-  drawCount: number;
-  matchCount: number;
-  tier: string;
-}
+type LeagueRecordInfoResponse =
+  components["schemas"]["LeagueRecordInfoResponse"];
 
 interface MemberInfoProps {
   image: string;
@@ -29,7 +25,7 @@ function MemberInfo({
   isOpen,
   onToggle,
 }: MemberInfoProps) {
-  const { winCount, loseCount, drawCount, matchCount, tier } =
+  const { win_count, lose_count, draw_count, match_count, tier } =
     leagueRecordInfoResponse;
 
   return (
@@ -39,11 +35,11 @@ function MemberInfo({
         <p className="text-black">{name}</p>
       </div>
       <div className="flex flex-[1] items-center">
-        <p className="text-black">{getTierWithEmoji(tier)}</p>
+        <p className="text-black">{getTierWithEmoji(tier as string)}</p>
       </div>
       <div className="flex flex-[1] items-center justify-between relative">
         <p className="text-black">
-          {matchCount}전 | {winCount}승 | {drawCount}무 | {loseCount}패
+          {match_count}전 | {win_count}승 | {draw_count}무 | {lose_count}패
         </p>
         <IconButton size="sm" color="transparent" onClick={onToggle}>
           <AlignJustify width="80%" height="80%" className="text-gray-400" />

--- a/app/(header)/my-club/member/MemberInfo.tsx
+++ b/app/(header)/my-club/member/MemberInfo.tsx
@@ -13,6 +13,7 @@ type LeagueRecordInfoResponse =
 interface MemberInfoProps {
   image: string;
   name: string;
+  role: string;
   leagueRecordInfoResponse: LeagueRecordInfoResponse;
   isOpen: boolean; // 드롭다운 상태
   onToggle: () => void; // 드롭다운 토글 함수
@@ -21,6 +22,7 @@ interface MemberInfoProps {
 function MemberInfo({
   image,
   name,
+  role,
   leagueRecordInfoResponse,
   isOpen,
   onToggle,
@@ -28,11 +30,27 @@ function MemberInfo({
   const { win_count, lose_count, draw_count, match_count, tier } =
     leagueRecordInfoResponse;
 
+  const changeRollWord = (roll: string) => {
+    switch (roll) {
+      case "ROLE_OWNER":
+        return "회장";
+      case "ROLE_MANAGER":
+        return "매니저";
+      case "ROLE_USER":
+        return "회원";
+      default:
+        return "";
+    }
+  };
+
   return (
     <div className="flex justify-center">
       <div className="flex flex-[1] items-center gap-8">
         <img src={image} alt="userImg" className="w-16 h-16 rounded-full" />
         <p className="text-black">{name}</p>
+      </div>
+      <div className="flex flex-[1] items-center">
+        <p className="text-black">{changeRollWord(role)}</p>
       </div>
       <div className="flex flex-[1] items-center">
         <p className="text-black">{getTierWithEmoji(tier as string)}</p>

--- a/app/(header)/my-club/member/page.tsx
+++ b/app/(header)/my-club/member/page.tsx
@@ -1,139 +1,33 @@
 "use client";
 
+import { useGetClubMembers } from "@/lib/api/hooks/clubMemberHook";
+import type { components } from "@/schemas/schema";
 import React, { useState } from "react";
 import MemberInfo from "./MemberInfo";
 
-const members = [
-  {
-    id: 1,
-    name: "a",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 12,
-      loseCount: 11,
-      drawCount: 0,
-      matchCount: 23,
-      tier: "GOLD",
-    },
-  },
-  {
-    id: 2,
-    name: "bb",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 33,
-      loseCount: 2,
-      drawCount: 0,
-      matchCount: 35,
-      tier: "SILVER",
-    },
-  },
-  {
-    id: 3,
-    name: "ccc",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 100,
-      loseCount: 150,
-      drawCount: 0,
-      matchCount: 250,
-      tier: "BRONZE",
-    },
-  },
-  {
-    id: 4,
-    name: "dddd",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "SILVER",
-    },
-  },
-  {
-    id: 5,
-    name: "eeeee",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "GOLD",
-    },
-  },
-  {
-    id: 6,
-    name: "ffffff",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "GOLD",
-    },
-  },
-  {
-    id: 7,
-    name: "gggggggg",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "GOLD",
-    },
-  },
-  {
-    id: 8,
-    name: "hhhhhhhh",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "GOLD",
-    },
-  },
-  {
-    id: 9,
-    name: "iiiiiiiii",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "BRONZE",
-    },
-  },
-  {
-    id: 10,
-    name: "jjjjjjjjjj",
-    image: "/images/dummy-image.jpg",
-    leagueRecordInfoResponse: {
-      winCount: 0,
-      loseCount: 0,
-      drawCount: 0,
-      matchCount: 0,
-      tier: "SILVER",
-    },
-  },
-];
+type ClubMemberResponse = components["schemas"]["ClubMemberResponse"];
+type LeagueRecordInfoResponse =
+  components["schemas"]["LeagueRecordInfoResponse"];
 
 function ClubMemberPage() {
-  const [openDropdownIndex, setOpenDropdownIndex] = useState<number | null>(
-    null,
-  );
+  const { data, error, isLoading } = useGetClubMembers();
+  const [openDropdownIndex, setOpenDropdownIndex] = useState<number | null>();
 
   const toggleDropdown = (index: number) => {
     setOpenDropdownIndex((prevIndex) => (prevIndex === index ? null : index));
   };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (!data) {
+    return <div>No data available</div>;
+  }
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  const members = [...data.ROLE_OWNER, ...data.ROLE_MANAGER, ...data.ROLE_USER];
 
   return (
     <div className="h-[466px]">
@@ -145,12 +39,14 @@ function ClubMemberPage() {
         </div>
         {members.map((member) => (
           <MemberInfo
-            key={member.id}
-            isOpen={openDropdownIndex === member.id}
-            image={member.image}
-            name={member.name}
-            leagueRecordInfoResponse={member.leagueRecordInfoResponse}
-            onToggle={() => toggleDropdown(member.id)}
+            key={member.club_member_id}
+            isOpen={openDropdownIndex === member.club_member_id}
+            image={member.image as string}
+            name={member.name as string}
+            leagueRecordInfoResponse={
+              member.league_record_info_response as LeagueRecordInfoResponse
+            }
+            onToggle={() => toggleDropdown(member.club_member_id as number)}
           />
         ))}
       </div>

--- a/app/(header)/my-club/member/page.tsx
+++ b/app/(header)/my-club/member/page.tsx
@@ -34,6 +34,7 @@ function ClubMemberPage() {
       <div className="flex flex-col gap-5 h-full overflow-scroll">
         <div className="flex font-bold text-gray-600 bg-gray-100 p-2 rounded-md">
           <div className="flex-[1]">멤버</div>
+          <div className="flex-[1]">직책</div>
           <div className="flex-[1]">티어</div>
           <div className="flex-[1]">전적</div>
         </div>
@@ -43,6 +44,7 @@ function ClubMemberPage() {
             isOpen={openDropdownIndex === member.club_member_id}
             image={member.image as string}
             name={member.name as string}
+            role={member.role as string}
             leagueRecordInfoResponse={
               member.league_record_info_response as LeagueRecordInfoResponse
             }

--- a/lib/api/functions/clubMemberFn.ts
+++ b/lib/api/functions/clubMemberFn.ts
@@ -1,0 +1,35 @@
+import type { components } from "@/schemas/schema";
+
+type ClubMemberResponse = components["schemas"]["ClubMemberResponse"];
+const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}`;
+
+interface ClubMembersData {
+  ROLE_OWNER: ClubMemberResponse[];
+  ROLE_MANAGER: ClubMemberResponse[];
+  ROLE_USER: ClubMemberResponse[];
+}
+
+export async function getClubMembers(): Promise<ClubMembersData> {
+  try {
+    const response = await fetch(`${BASE_URL}/clubs/1/clubMembers`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    return data as ClubMembersData;
+  } catch (error) {
+    console.error(error);
+    return {
+      ROLE_OWNER: [],
+      ROLE_MANAGER: [],
+      ROLE_USER: [],
+    };
+  }
+}

--- a/lib/api/functions/clubMemberFn.ts
+++ b/lib/api/functions/clubMemberFn.ts
@@ -11,6 +11,7 @@ interface ClubMembersData {
 
 export async function getClubMembers(): Promise<ClubMembersData> {
   try {
+    /* TODO(iamgyu): 현재 ID가 지정해준 값으로 들어가 있기 때문에 추후에 변경 필요 */
     const response = await fetch(`${BASE_URL}/clubs/1/clubMembers`, {
       method: "GET",
       headers: {

--- a/lib/api/hooks/clubMemberHook.ts
+++ b/lib/api/hooks/clubMemberHook.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getClubMembers } from "../functions/clubMemberFn";
+
+export const useGetClubMembers = () => {
+  return useQuery({
+    queryKey: ["clubMembersData"],
+    queryFn: getClubMembers,
+  });
+};


### PR DESCRIPTION
- Close #113 

## What is this PR? 🔍

- 기능 : 멤버 페이지 API 연동
- issue : #113

## Changes 📝
- 멤버 페이지에 API를 연동하였습니다.
- 추가적으로 직책이 보여야 될 것 같아 직책을 추가하였습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/47529d53-9b5c-4d79-8a8f-f844a10fc7dc">

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
- 현재 path variable에 clubId가 들어가는 것에 대해 정해지지 않아 임의로 clubid가 1인 것으로 가정하고 API 호출을 하였습니다.
- API 호출한 후에 컴포넌트를 불러올 때 타입을 'as'를 통해 강제로 지정해주고 있습니다. 이 부분도 추후웨 리팩토링 때 undefined를 해결할 다른 방법을 생각해봐야 될 것 같습니다.
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
