### PR TITLE
feat: 동호회 관리 페이지 API 연동

### DIFF
--- a/app/(header)/club/[clubId]/layout.tsx
+++ b/app/(header)/club/[clubId]/layout.tsx
@@ -75,7 +75,7 @@ function ClubLayout() {
               <ClubMemberPages />
             </TabsContent>
             <TabsContent value="manage">
-              <ClubManagePages />
+              <ClubManagePages clubData={data} />
             </TabsContent>
           </>
         )}

--- a/app/(header)/club/[clubId]/manage/page.tsx
+++ b/app/(header)/club/[clubId]/manage/page.tsx
@@ -4,14 +4,18 @@ import ClubInfoInputDescription from "@/components/common/clubInfoInput/ClubInfo
 import ClubInfoInputImage from "@/components/common/clubInfoInput/ClubInfoInputImage";
 import ClubInfoInputName from "@/components/common/clubInfoInput/ClubInfoInputName";
 import { Button } from "@/components/ui/Button";
+import type { components } from "@/schemas/schema";
 import { useState } from "react";
 
-function ClubManagePage() {
-  const [imagePreview, setImagePreview] = useState("/images/dummy-image.jpg");
-  const [clubName, setClubName] = useState("기존 동호회 이름");
-  const [text, setText] = useState(
-    "안녕하세요 동호회 입니다. 안녕하세요 동호회 입니다.안녕하세요 동호회입니다. 안녕하세요 동호회 입니다.안녕하세요 동호회 입니다.안녕하세요 동호회 입니다.안녕하세요 동호회 입니다. 안녕하세요 동호회입니다.안녕하세요 동호회 입니다. 안녕하세요 동호회 입니다.안녕하세요동호회 입니다. 안녕하세요 동호회 입니다.안녕하세요 동호회 입니다.안녕하세요 동호회 입니다.안녕하세요 동호회 입니다. 안녕하세요 동호회입니다.안녕하세요 동호회 입니다. 안녕하세요 동호회 입니다.",
-  );
+type ClubDetailsResponse = components["schemas"]["ClubDetailsResponse"];
+
+interface ClubManagePageProps {
+  clubData: ClubDetailsResponse;
+}
+function ClubManagePage({ clubData }: ClubManagePageProps) {
+  const [imagePreview, setImagePreview] = useState(clubData.club_image);
+  const [clubName, setClubName] = useState(clubData.club_name);
+  const [text, setText] = useState(clubData.club_description);
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -25,18 +29,24 @@ function ClubManagePage() {
   return (
     <div className="flex space-x-8 w-full h-[464px] items-center">
       <ClubInfoInputImage
-        imagePreview={imagePreview}
+        imagePreview={imagePreview as string}
         onImageChange={handleImageChange}
       />
       <div className="flex flex-col flex-1 h-[400px] gap-4">
-        <ClubInfoInputName
-          clubName={clubName}
-          onChange={(e) => setClubName(e.target.value)}
-        />
-        <ClubInfoInputDescription
-          description={text}
-          onChange={(e) => setText(e.target.value)}
-        />
+        <div className="flex flex-col gap-1">
+          <p className="text-black font-bold text-lg">동호회 이름</p>
+          <ClubInfoInputName
+            clubName={clubName}
+            onChange={(e) => setClubName(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1 h-full">
+          <p className="text-black font-bold text-lg">동호회 소개</p>
+          <ClubInfoInputDescription
+            description={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+        </div>
         <div className="w-full flex justify-end">
           <Button className="place-items-end">변경 저장</Button>
         </div>

--- a/app/(header)/club/[clubId]/manage/page.tsx
+++ b/app/(header)/club/[clubId]/manage/page.tsx
@@ -4,54 +4,130 @@ import ClubInfoInputDescription from "@/components/common/clubInfoInput/ClubInfo
 import ClubInfoInputImage from "@/components/common/clubInfoInput/ClubInfoInputImage";
 import ClubInfoInputName from "@/components/common/clubInfoInput/ClubInfoInputName";
 import { Button } from "@/components/ui/Button";
+import { usePatchClubs, usePostClubsImg } from "@/lib/api/hooks/clubHook";
 import type { components } from "@/schemas/schema";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 
 type ClubDetailsResponse = components["schemas"]["ClubDetailsResponse"];
+type ClubUpdate = components["schemas"]["ClubUpdateRequest"];
 
 interface ClubManagePageProps {
   clubData: ClubDetailsResponse;
 }
+
 function ClubManagePage({ clubData }: ClubManagePageProps) {
-  const [imagePreview, setImagePreview] = useState(clubData.club_image);
-  const [clubName, setClubName] = useState(clubData.club_name);
-  const [text, setText] = useState(clubData.club_description);
+  const [imgUrl, setImgUrl] = useState<string>(clubData.club_image as string);
+  const { mutate: patchClub } = usePatchClubs(clubData.club_id ?? 0);
+  const { mutate: patchClubImg } = usePostClubsImg();
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    setError,
+    clearErrors,
+    formState: { errors },
+  } = useForm<ClubUpdate>({
+    defaultValues: {
+      club_name: clubData.club_name,
+      club_description: clubData.club_description,
+      club_image: imgUrl,
+    },
+    mode: "onBlur",
+  });
+
+  const uploadImage = (file: File) => {
+    const formData = new FormData();
+    formData.append("multipartFile", file);
+
+    patchClubImg(formData, {
+      onSuccess: (data) => {
+        setImgUrl(data);
+        setValue("club_image", data);
+        clearErrors("club_image");
+      },
+      onError: () => {
+        setError("club_image", {
+          type: "manual",
+          message: "이미지 업로드에 실패했습니다",
+        });
+      },
+    });
+  };
+
+  const handleUpdateclub = (data: ClubUpdate) => {
+    const newData: ClubUpdate = {
+      club_name: data.club_name,
+      club_description: data.club_description,
+      club_image: data.club_image,
+    };
+
+    patchClub(newData, {
+      onSuccess: () => {
+        alert("변경이 완료되었습니다!");
+      },
+    });
+  };
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      // TODO(iamgyu): 서버로 이미지 업로드 로직 추가
-      const imageUrl = URL.createObjectURL(file);
-      setImagePreview(imageUrl);
+      uploadImage(file);
     }
   };
 
   return (
-    <div className="flex space-x-8 w-full h-[464px] items-center">
-      <ClubInfoInputImage
-        imagePreview={imagePreview as string}
-        onImageChange={handleImageChange}
-      />
+    <form
+      onSubmit={handleSubmit(handleUpdateclub)}
+      method="patch"
+      className="flex space-x-8 w-full h-[464px] items-center"
+    >
+      <div className="flex flex-col gap-1 justify-center">
+        {/* 파일 선택 필드를 register로 관리 */}
+        <input
+          type="text"
+          className="hidden"
+          {...register("club_image", {
+            required: "이미지를 선택해주세요",
+          })}
+        />
+        <ClubInfoInputImage
+          imagePreview={imgUrl}
+          onImageChange={(e) => handleImageChange(e)}
+        />
+        {errors.club_image && (
+          <p className="text-red-500">{errors.club_image.message}</p>
+        )}
+      </div>
       <div className="flex flex-col flex-1 h-[400px] gap-4">
         <div className="flex flex-col gap-1">
           <p className="text-black font-bold text-lg">동호회 이름</p>
           <ClubInfoInputName
-            clubName={clubName}
-            onChange={(e) => setClubName(e.target.value)}
+            {...register("club_name", {
+              required: "동호회 이름을 입력하세요",
+            })}
           />
+          {errors.club_name && (
+            <p className="text-red-500">{errors.club_name.message}</p>
+          )}
         </div>
         <div className="flex flex-col gap-1 h-full">
           <p className="text-black font-bold text-lg">동호회 소개</p>
           <ClubInfoInputDescription
-            description={text}
-            onChange={(e) => setText(e.target.value)}
+            {...register("club_description", {
+              required: "동호회 설명을 입력하세요",
+            })}
           />
+          {errors.club_description && (
+            <p className="text-red-500">{errors.club_description.message}</p>
+          )}
         </div>
         <div className="w-full flex justify-end">
           <Button className="place-items-end">변경 저장</Button>
         </div>
       </div>
-    </div>
+    </form>
   );
 }
 

--- a/components/common/clubInfoInput/ClubInfoInputName.tsx
+++ b/components/common/clubInfoInput/ClubInfoInputName.tsx
@@ -7,15 +7,15 @@ interface ClubInfoInputNameProps
 
 const ClubInfoInputName = forwardRef<HTMLInputElement, ClubInfoInputNameProps>(
   (props, ref) => {
-    const { clubName } = props;
+    const { clubName, ...rest } = props;
     return (
       <input
         type="text"
         className="text-2xl font-bold text-black border border-gray-300 rounded-md p-1"
         placeholder="이름을 입력하세요"
         ref={ref}
-        defaultValue={clubName}
-        {...props}
+        defaultValue={clubName} // clubName은 사용하되, DOM에 전달하지 않음
+        {...rest} // 나머지 props 전달
       />
     );
   },

--- a/lib/api/functions/clubFn.ts
+++ b/lib/api/functions/clubFn.ts
@@ -6,6 +6,8 @@ type ClubCreateRequest = components["schemas"]["ClubCreateRequest"];
 type ClubCreateResponse = components["schemas"]["ClubCreateResponse"];
 type ClubDetailsResponse = components["schemas"]["ClubDetailsResponse"];
 type ClubUpdateRequest = components["schemas"]["ClubUpdateRequest"];
+type ClubUpdateResponse = components["schemas"]["ClubUpdateResponse"];
+
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}`;
 
 export async function getClubs(): Promise<Club[]> {
@@ -68,6 +70,24 @@ export const getClubsById = async (
 
   if (!response.ok) {
     throw new Error("동호회 정보를 받아오는데 실패했습니다.");
+  }
+
+  return response.json();
+};
+
+export const patchClubs = async (
+  clubUpdateData: ClubUpdateRequest,
+  clubId: number,
+): Promise<ClubUpdateResponse> => {
+  const response = await fetch(`${BASE_URL}/clubs/${clubId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(clubUpdateData),
+  });
+
+  if (!response.ok) {
+    throw new Error("동호회 정보 수정에 실패했습니다.");
   }
 
   return response.json();

--- a/lib/api/functions/clubFn.ts
+++ b/lib/api/functions/clubFn.ts
@@ -5,7 +5,7 @@ type Club = components["schemas"]["ClubCardResponse"];
 type ClubCreateRequest = components["schemas"]["ClubCreateRequest"];
 type ClubCreateResponse = components["schemas"]["ClubCreateResponse"];
 type ClubDetailsResponse = components["schemas"]["ClubDetailsResponse"];
-
+type ClubUpdateRequest = components["schemas"]["ClubUpdateRequest"];
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}`;
 
 export async function getClubs(): Promise<Club[]> {

--- a/lib/api/hooks/clubHook.ts
+++ b/lib/api/hooks/clubHook.ts
@@ -1,6 +1,7 @@
 import {
   getClubs,
   getClubsById,
+  patchClubs,
   postClubs,
   postClubsImg,
 } from "@/lib/api/functions/clubFn";
@@ -8,6 +9,7 @@ import type { components } from "@/schemas/schema";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 type ClubCreate = components["schemas"]["ClubCreateRequest"];
+type ClubUpdate = components["schemas"]["ClubUpdateRequest"];
 
 export const useGetClubs = () => {
   return useQuery({
@@ -39,5 +41,18 @@ export const useGetClubsById = (clubId: number) => {
   return useQuery({
     queryKey: ["clubsDataById", clubId],
     queryFn: () => getClubsById(clubId),
+  });
+};
+
+export const usePatchClubs = (clubId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (clubUpdateData: ClubUpdate) =>
+      patchClubs(clubUpdateData, clubId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clubsData"] });
+    },
+    onError: (error: Error) => alert(error),
   });
 };


### PR DESCRIPTION
- Close #114 

## What is this PR? 🔍

- 기능 : 동호회 관리 페이지 API 연동
- issue : #114

## Changes 📝
- 동호회 이름, 소개, 이미지를 변경할 수 있도록 하였습니다.
- 변경이 완료 / 실패는 alert를 통해 사용자가 확인할 수 있도록 하였습니다.
- react-hook-form을 이용하여 입력이 무조건 있을 수 있도록 하였습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/13c0beb2-9bcb-4327-a39e-d382b588ce8c">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8881f33d-cb70-4191-b5e5-5679010bf3a3">
<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
