### PR TITLE
feat: 일별 조회 api 연동

### DIFF
--- a/app/(header)/club/[clubId]/schedule/ScheduleList.tsx
+++ b/app/(header)/club/[clubId]/schedule/ScheduleList.tsx
@@ -31,7 +31,6 @@ function ScheduleList(props: ScheduleListProps) {
 
   return (
     <div className="w-full px-6 py-3 bg-white relative">
-      {/* TODO(Yejin0O0): api 연동 시 링크 수정 작업 필요 */}
       <Link href={`/club/${clubId}/schedule/create`}>
         <IconButton
           size="sm"
@@ -48,14 +47,13 @@ function ScheduleList(props: ScheduleListProps) {
         </h1>
       </div>
 
-      <div className="grid gap-4 h-[27rem] overflow-y-auto">
+      <div className="flex flex-col justify-start gap-4 h-[27rem] overflow-y-auto">
         {Array.isArray(schedules) &&
           schedules.map((schedule: DateLeagues) => (
-            // TODO(Yejin0O0): mock data or data 변수 이름 다시 생각해보기
             // TODO(Yejin0O0): api 연동 시 링크 수정 작업 필요
             <Link
               key={schedule.league_id}
-              href={`/my-club/schedule/${schedule.league_id}`}
+              href={`/club/${clubId}/schedule/${schedule.league_id}`}
             >
               <div className="bg-white py-4 px-6 rounded-xl border border-solid hover:shadow-lg transform  transition-transform duration-300 cursor-pointer">
                 <div className="flex justify-between items-start mb-4">

--- a/app/(header)/club/[clubId]/schedule/ScheduleList.tsx
+++ b/app/(header)/club/[clubId]/schedule/ScheduleList.tsx
@@ -29,6 +29,52 @@ function ScheduleList(props: ScheduleListProps) {
     refetch();
   }, [selectedDate]);
 
+  const renderSchedule = () => {
+    if (schedules !== undefined && schedules.length > 0) {
+      return schedules.map((schedule: DateLeagues) => (
+        <Link
+          key={schedule.league_id}
+          href={`/club/${clubId}/schedule/${schedule.league_id}`}
+        >
+          <div className="bg-white py-4 px-6 rounded-xl border border-solid hover:shadow-lg transform transition-transform duration-300 cursor-pointer">
+            <div className="flex justify-between items-start mb-4">
+              <div>
+                <h2 className="text-lg font-bold text-gray-900">
+                  {schedule.league_name}
+                </h2>
+                <Text color="gray" className="text-sm mt-1">
+                  {getLeagueType(schedule.match_type as string)}
+                </Text>
+              </div>
+              <Text className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
+                {getTierWithEmoji(schedule.required_tier as string)}
+              </Text>
+            </div>
+            <div className="flex justify-between items-center text-gray-600">
+              <div>
+                <Text className="text-sm">
+                  모집 기한:{" "}
+                  {format(new Date(schedule.closed_at as string), "MM/dd")}
+                </Text>
+              </div>
+              <div>
+                <Text className="text-sm">
+                  {schedule.recruited_member_count} /{" "}
+                  {schedule.player_limit_count} 명
+                </Text>
+              </div>
+            </div>
+          </div>
+        </Link>
+      ));
+    }
+    return (
+      <div className="text-center text-gray-500 py-10">
+        <p className="text-lg">아직 등록된 스케줄이 없습니다</p>
+      </div>
+    );
+  };
+
   return (
     <div className="w-full px-6 py-3 bg-white relative">
       <Link href={`/club/${clubId}/schedule/create`}>
@@ -48,44 +94,7 @@ function ScheduleList(props: ScheduleListProps) {
       </div>
 
       <div className="flex flex-col justify-start gap-4 h-[27rem] overflow-y-auto">
-        {Array.isArray(schedules) &&
-          schedules.map((schedule: DateLeagues) => (
-            // TODO(Yejin0O0): api 연동 시 링크 수정 작업 필요
-            <Link
-              key={schedule.league_id}
-              href={`/club/${clubId}/schedule/${schedule.league_id}`}
-            >
-              <div className="bg-white py-4 px-6 rounded-xl border border-solid hover:shadow-lg transform  transition-transform duration-300 cursor-pointer">
-                <div className="flex justify-between items-start mb-4">
-                  <div>
-                    <h2 className="text-lg font-bold text-gray-900">
-                      {schedule.league_name}
-                    </h2>
-                    <Text color="gray" className="text-sm mt-1">
-                      {getLeagueType(schedule.match_type as string)}
-                    </Text>
-                  </div>
-                  <Text className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
-                    {getTierWithEmoji(schedule.required_tier as string)}
-                  </Text>
-                </div>
-                <div className="flex justify-between items-center text-gray-600">
-                  <div>
-                    <Text className="text-sm">
-                      모집 기한:{" "}
-                      {format(new Date(schedule.closed_at as string), "MM/dd")}
-                    </Text>
-                  </div>
-                  <div>
-                    <Text className="text-sm">
-                      {schedule.recruited_member_count} /{" "}
-                      {schedule.player_limit_count} 명
-                    </Text>
-                  </div>
-                </div>
-              </div>
-            </Link>
-          ))}
+        {renderSchedule()}
       </div>
     </div>
   );

--- a/app/(header)/club/[clubId]/schedule/ScheduleList.tsx
+++ b/app/(header)/club/[clubId]/schedule/ScheduleList.tsx
@@ -1,101 +1,33 @@
 import IconButton from "@/components/ui/IconButton";
 import { Text } from "@/components/ui/Text";
+import { useGetDateLeagues } from "@/lib/api/hooks/leagueHook";
+import type { components } from "@/schemas/schema";
+import { getLeagueType } from "@/utils/getLeagueType";
 import { getTierWithEmoji } from "@/utils/getTierWithEmoji";
 import { format } from "date-fns";
 import { CalendarPlus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-
-const schedules = [
-  {
-    id: 1,
-    title: "일정 제목 1",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "GOLD",
-    type: "단식",
-  },
-  {
-    id: 2,
-    title: "일정 제목 2",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "SILVER",
-    type: "단식",
-  },
-  {
-    id: 3,
-    title: "일정 제목 3",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "BRONZE",
-    type: "단식",
-  },
-  {
-    id: 4,
-    title: "일정 제목 4",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "GOLD",
-    type: "단식",
-  },
-  {
-    id: 5,
-    title: "일정 제목 5",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "SILVER",
-    type: "단식",
-  },
-  {
-    id: 6,
-    title: "일정 제목 6",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "BRONZE",
-    type: "단식",
-  },
-  {
-    id: 7,
-    title: "일정 제목 7",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "GOLD",
-    type: "단식",
-  },
-  {
-    id: 8,
-    title: "일정 제목 8",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "SILVER",
-    type: "단식",
-  },
-  {
-    id: 9,
-    title: "일정 제목 9",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "BRONZE",
-    type: "단식",
-  },
-  {
-    id: 10,
-    title: "일정 제목 10",
-    deadline: "8/12",
-    participants: "8/24 명",
-    tier: "GOLD",
-    type: "단식",
-  },
-];
+import { useEffect } from "react";
 
 interface ScheduleListProps {
   selectedDate: Date;
 }
 
+type DateLeagues = components["schemas"]["LeagueByDateResponse"];
+
 function ScheduleList(props: ScheduleListProps) {
   const { selectedDate } = props;
-  const clubId = usePathname().split("/")[2];
+  const clubId = Number(usePathname().split("/")[2]);
+  const { data: schedules, refetch } = useGetDateLeagues(
+    clubId,
+    format(selectedDate, "yyyy-MM-dd"),
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    refetch();
+  }, [selectedDate]);
 
   return (
     <div className="w-full px-6 py-3 bg-white relative">
@@ -117,37 +49,45 @@ function ScheduleList(props: ScheduleListProps) {
       </div>
 
       <div className="grid gap-4 h-[27rem] overflow-y-auto">
-        {schedules.map((schedule) => (
-          // TODO(Yejin0O0): mock data or data 변수 이름 다시 생각해보기
-          // TODO(Yejin0O0): api 연동 시 링크 수정 작업 필요
-          <Link key={schedule.id} href={`/my-club/schedule/${schedule.id}`}>
-            <div className="bg-white py-4 px-6 rounded-xl border border-solid hover:shadow-lg transform  transition-transform duration-300 cursor-pointer">
-              <div className="flex justify-between items-start mb-4">
-                <div>
-                  <h2 className="text-lg font-bold text-gray-900">
-                    {schedule.title}
-                  </h2>
-                  <Text color="gray" className="text-sm mt-1">
-                    {schedule.type}
+        {Array.isArray(schedules) &&
+          schedules.map((schedule: DateLeagues) => (
+            // TODO(Yejin0O0): mock data or data 변수 이름 다시 생각해보기
+            // TODO(Yejin0O0): api 연동 시 링크 수정 작업 필요
+            <Link
+              key={schedule.league_id}
+              href={`/my-club/schedule/${schedule.league_id}`}
+            >
+              <div className="bg-white py-4 px-6 rounded-xl border border-solid hover:shadow-lg transform  transition-transform duration-300 cursor-pointer">
+                <div className="flex justify-between items-start mb-4">
+                  <div>
+                    <h2 className="text-lg font-bold text-gray-900">
+                      {schedule.league_name}
+                    </h2>
+                    <Text color="gray" className="text-sm mt-1">
+                      {getLeagueType(schedule.match_type as string)}
+                    </Text>
+                  </div>
+                  <Text className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
+                    {getTierWithEmoji(schedule.required_tier as string)}
                   </Text>
                 </div>
-                <Text className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
-                  {getTierWithEmoji(schedule.tier)}
-                </Text>
-              </div>
-              <div className="flex justify-between items-center text-gray-600">
-                <div>
-                  <Text className="text-sm">
-                    모집 기한: {schedule.deadline}
-                  </Text>
+                <div className="flex justify-between items-center text-gray-600">
+                  <div>
+                    <Text className="text-sm">
+                      모집 기한:{" "}
+                      {format(new Date(schedule.closed_at as string), "MM/dd")}
+                    </Text>
+                  </div>
+                  <div>
+                    <Text className="text-sm">
+                      {schedule.recruited_member_count} /{" "}
+                      {schedule.player_limit_count} 명
+                    </Text>
+                  </div>
                 </div>
-                <div>
-                  <Text className="text-sm">{schedule.participants}</Text>
-                </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))}
       </div>
     </div>
   );

--- a/app/(header)/club/[clubId]/schedule/page.tsx
+++ b/app/(header)/club/[clubId]/schedule/page.tsx
@@ -14,16 +14,14 @@ type MonthLeagues = components["schemas"]["LeagueReadResponse"];
 
 export default function ClubSchedulePage() {
   const [date, setDate] = useState<Date>(new Date());
+  const [month, setMonth] = useState<string>(format(new Date(), "yyyy-MM"));
   const clubId = Number(usePathname().split("/")[2]);
-  const { data: scheduleList, refetch } = useGetMonthLeagues(
-    clubId,
-    format(date, "yyyy-MM"),
-  );
+  const { data: scheduleList, refetch } = useGetMonthLeagues(clubId, month);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     refetch();
-  }, [date]);
+  }, [month]);
 
   return (
     <div className="w-full flex">
@@ -37,7 +35,10 @@ export default function ClubSchedulePage() {
           }
         }}
         onMonthChange={(newMonth) => {
-          setDate(newMonth);
+          const newMonthStr = format(newMonth, "yyyy-MM");
+          if (newMonthStr !== month) {
+            setMonth(newMonthStr);
+          }
         }}
         locale={ko}
         className="rounded-md text-gray-800"

--- a/constants/loginOauthUrl.ts
+++ b/constants/loginOauthUrl.ts
@@ -1,5 +1,5 @@
 export const NAVER_OAUTH_URL =
-  "https://api.badminton.run/oauth2/authorization/naver";
+  "https://apit.badminton.run/oauth2/authorization/naver";
 
 export const GOOGLE_OAUTH_URL =
   "https://api.badminton.run/oauth2/oauth2/authorization/google";

--- a/lib/api/functions/leagueFn.ts
+++ b/lib/api/functions/leagueFn.ts
@@ -27,7 +27,7 @@ export const getMonthLeagues = async (
   date: string,
 ): Promise<MonthLeaguesResponse> => {
   const response = await fetch(
-    `${BASE_URL}/clubs/${clubId}/leagues?date=${date}`,
+    `${BASE_URL}/clubs/${clubId}/leagues/month?date=${date}`,
     {
       method: "GET",
       headers: {
@@ -38,6 +38,26 @@ export const getMonthLeagues = async (
   );
   if (!response.ok) {
     throw new Error("리그 정보를 확인할 수 없습니다.");
+  }
+  return response.json();
+};
+
+export const getDateLeagues = async (
+  clubId: number,
+  date: string,
+): Promise<MonthLeaguesResponse> => {
+  const response = await fetch(
+    `${BASE_URL}/clubs/${clubId}/leagues/date?date=${date}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    },
+  );
+  if (!response.ok) {
+    throw new Error("리그 일별 정보를 확인할 수 없습니다.");
   }
   return response.json();
 };

--- a/lib/api/functions/leagueFn.ts
+++ b/lib/api/functions/leagueFn.ts
@@ -45,7 +45,7 @@ export const getMonthLeagues = async (
 export const getDateLeagues = async (
   clubId: number,
   date: string,
-): Promise<MonthLeaguesResponse> => {
+): Promise<MonthLeaguesResponse[]> => {
   const response = await fetch(
     `${BASE_URL}/clubs/${clubId}/leagues/date?date=${date}`,
     {

--- a/lib/api/hooks/leagueHook.ts
+++ b/lib/api/hooks/leagueHook.ts
@@ -1,6 +1,10 @@
 import type { components } from "@/schemas/schema";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getMonthLeagues, postLeagues } from "../functions/leagueFn";
+import {
+  getDateLeagues,
+  getMonthLeagues,
+  postLeagues,
+} from "../functions/leagueFn";
 
 type LeagueCreateRequest = components["schemas"]["LeagueCreateRequest"];
 
@@ -12,6 +16,7 @@ export const usePostLeagues = (clubId: number) => {
       postLeagues(leagueData, clubId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["leaguesData"] });
+      queryClient.invalidateQueries({ queryKey: ["leaguesDateData"] });
     },
     onError: (error: Error) => alert(error),
   });
@@ -21,5 +26,12 @@ export const useGetMonthLeagues = (clubId: number, date: string) => {
   return useQuery({
     queryKey: ["leaguesData"],
     queryFn: () => getMonthLeagues(clubId, date),
+  });
+};
+
+export const useGetDateLeagues = (clubId: number, date: string) => {
+  return useQuery({
+    queryKey: ["leaguesDateData"],
+    queryFn: () => getDateLeagues(clubId, date),
   });
 };

--- a/schemas/schema.d.ts
+++ b/schemas/schema.d.ts
@@ -4,2017 +4,2086 @@
  */
 
 export interface paths {
-    "/v1/members/profileImage": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * 프로필 사진을 수정합니다
-         * @description 프로필 사진을 수정합니다
-         */
-        put: operations["updateProfileImage"];
-        /**
-         * 프로필 사진을 S3에 업로드 합니다
-         * @description 프로필 사진을 S3에 업로드합니다
-         */
-        post: operations["uploadProfileImage"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/v1/members/profileImage": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members/win": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 승리 기록 추가
-         * @description 회원의 리그 기록에 승리를 추가합니다
-         */
-        post: operations["addWin"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    /**
+     * 프로필 사진을 수정합니다
+     * @description 프로필 사진을 수정합니다
+     */
+    put: operations["updateProfileImage"];
+    /**
+     * 프로필 사진을 S3에 업로드 합니다
+     * @description 프로필 사진을 S3에 업로드합니다
+     */
+    post: operations["uploadProfileImage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/members/win": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 액세스 토큰을 재발급합니다
-         * @description 리프레시 토큰을 이용해서 액세스 토큰을 재발급합니다
-         */
-        post: operations["refreshToken"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 승리 기록 추가
+     * @description 회원의 리그 기록에 승리를 추가합니다
+     */
+    post: operations["addWin"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/members/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members/lose": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 패배 기록 추가
-         * @description 회원의 리그 기록에 패배를 추가합니다
-         */
-        post: operations["addLose"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 액세스 토큰을 재발급합니다
+     * @description 리프레시 토큰을 이용해서 액세스 토큰을 재발급합니다
+     */
+    post: operations["refreshToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/members/lose": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members/logout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 로그아웃을 합니다
-         * @description 쿠키에서 JWT 토큰을 제거해 로그아웃을 합니다
-         */
-        post: operations["logout"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 패배 기록 추가
+     * @description 회원의 리그 기록에 패배를 추가합니다
+     */
+    post: operations["addLose"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/members/logout": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 전체 동호회 조회
-         * @description 전체 동호회를 조회합니다.
-         */
-        get: operations["readAllClub"];
-        put?: never;
-        /**
-         * 동호회 추가
-         * @description 동호회를 추가합니다.
-         */
-        post: operations["createClub"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 로그아웃을 합니다
+     * @description 쿠키에서 JWT 토큰을 제거해 로그아웃을 합니다
+     */
+    post: operations["logout"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 경기를 생성합니다.
-         * @description 경기 생성하고를 데이터베이스에 저장합니다.
-         */
-        post: operations["createLeague"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 전체 동호회 조회
+     * @description 전체 동호회를 조회합니다.
+     */
+    get: operations["readAllClub"];
+    put?: never;
+    /**
+     * 동호회 추가
+     * @description 동호회를 추가합니다.
+     */
+    post: operations["createClub"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/{leagueId}/participation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 경기 참여 신청
-         * @description 동호회 회원이 경기 일정에 참여 신청을 합니다.
-         */
-        post: operations["participateInLeague"];
-        /**
-         * 경기 참여 신청 취소
-         * @description 경기 참여 신청을 취소합니다.
-         */
-        delete: operations["cancelLeagueParticipation"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 경기를 생성합니다.
+     * @description 경기 생성하고를 데이터베이스에 저장합니다.
+     */
+    post: operations["createLeague"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/{leagueId}/participation": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/{leagueId}/matches": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 대진표 조회
-         * @description 대진표를 조회합니다.
-         */
-        get: operations["getMatches"];
-        put?: never;
-        /**
-         * 대진표 생성
-         * @description 대진표를 생성합니다.
-         */
-        post: operations["makeMatches"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 경기 참여 신청
+     * @description 동호회 회원이 경기 일정에 참여 신청을 합니다.
+     */
+    post: operations["participateInLeague"];
+    /**
+     * 경기 참여 신청 취소
+     * @description 경기 참여 신청을 취소합니다.
+     */
+    delete: operations["cancelLeagueParticipation"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/{leagueId}/matches": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/{leagueId}/matches/{matchId}/set/{setIndex}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** 세트별 점수 저장 */
-        post: operations["updateSetsScore"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 대진표 조회
+     * @description 대진표를 조회합니다.
+     */
+    get: operations["getMatches"];
+    put?: never;
+    /**
+     * 대진표 생성
+     * @description 대진표를 생성합니다.
+     */
+    post: operations["makeMatches"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/{leagueId}/matches/{matchId}/set/{setIndex}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/{leagueId}/matches/details": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** 대진표 대진별, 세트별, 점수 초기화 */
-        post: operations["makeMatchesDetails"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** 세트별 점수 저장 */
+    post: operations["updateSetsScore"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/{leagueId}/matches/details": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/clubMembers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 동호회 회원 전체 조회
-         * @description 동호회에 가입한 회원들의 리스트를 조회합니다.
-         */
-        get: operations["getClubMembersInClub"];
-        put?: never;
-        /**
-         * 동호회 가입 신청
-         * @description 동호회에 가입을 신청합니다.
-         */
-        post: operations["joinClub"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** 대진표 대진별, 세트별, 점수 초기화 */
+    post: operations["makeMatchesDetails"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/clubMembers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/images": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 클럽 이미지 업로드
-         * @description 이미지를 S3에 업로드하는 API 입니다.
-         */
-        post: operations["saveImage"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 동호회 회원 전체 조회
+     * @description 동호회에 가입한 회원들의 리스트를 조회합니다.
+     */
+    get: operations["getClubMembersInClub"];
+    put?: never;
+    /**
+     * 동호회 가입 신청
+     * @description 동호회에 가입을 신청합니다.
+     */
+    post: operations["joinClub"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/images": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 동호회 조회
-         * @description 동호회를 조회합니다.
-         */
-        get: operations["readClub"];
-        put?: never;
-        post?: never;
-        /**
-         * 동호회 삭제
-         * @description 동호회를 삭제합니다.
-         */
-        delete: operations["deleteClub"];
-        options?: never;
-        head?: never;
-        /**
-         * 동호회 수정
-         * @description 동호회를 수정합니다.
-         */
-        patch: operations["updateClub"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 클럽 이미지 업로드
+     * @description 이미지를 S3에 업로드하는 API 입니다.
+     */
+    post: operations["saveImage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/{leagueId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 특정 경기를 조회합니다.
-         * @description 특정 경기를 경기 아이디를 통해 데이터베이스에서 조회합니다.
-         */
-        get: operations["leagueRead"];
-        put?: never;
-        post?: never;
-        /**
-         * 특정 경기를 삭제합니다.
-         * @description 특정 경기를 데이터베이스 테이블에서 제거합니다.
-         */
-        delete: operations["deleteLeague"];
-        options?: never;
-        head?: never;
-        /**
-         * 경기의 세부 정보를 변경합니다.
-         * @description 경기 제목, 경기 상태 등을 변경할 수 있습니다.
-         */
-        patch: operations["updateLeague"];
-        trace?: never;
+    /**
+     * 동호회 조회
+     * @description 동호회를 조회합니다.
+     */
+    get: operations["readClub"];
+    put?: never;
+    post?: never;
+    /**
+     * 동호회 삭제
+     * @description 동호회를 삭제합니다.
+     */
+    delete: operations["deleteClub"];
+    options?: never;
+    head?: never;
+    /**
+     * 동호회 수정
+     * @description 동호회를 수정합니다.
+     */
+    patch: operations["updateClub"];
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/{leagueId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/clubMembers/role": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 동호회원 역할 변경
-         * @description 동호회원의 역할을 변경합니다.
-         */
-        patch: operations["updateClubMemberRole"];
-        trace?: never;
+    /**
+     * 특정 경기를 조회합니다.
+     * @description 특정 경기를 경기 아이디를 통해 데이터베이스에서 조회합니다.
+     */
+    get: operations["leagueRead"];
+    put?: never;
+    post?: never;
+    /**
+     * 특정 경기를 삭제합니다.
+     * @description 특정 경기를 데이터베이스 테이블에서 제거합니다.
+     */
+    delete: operations["deleteLeague"];
+    options?: never;
+    head?: never;
+    /**
+     * 경기의 세부 정보를 변경합니다.
+     * @description 경기 제목, 경기 상태 등을 변경할 수 있습니다.
+     */
+    patch: operations["updateLeague"];
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/clubMembers/role": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/clubMembers/expel": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 동호회원 강제 탈퇴시키기
-         * @description 동호회원을 강제 탈퇴시킵니다.
-         */
-        patch: operations["expelClubMember"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 동호회원 역할 변경
+     * @description 동호회원의 역할을 변경합니다.
+     */
+    patch: operations["updateClubMemberRole"];
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/clubMembers/expel": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/clubMembers/ban": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 동호회원 정지
-         * @description 동호회원의 활동을 정지시킵니다.
-         */
-        patch: operations["banClubMember"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 동호회원 강제 탈퇴시키기
+     * @description 동호회원을 강제 탈퇴시킵니다.
+     */
+    patch: operations["expelClubMember"];
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/clubMembers/ban": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members/myPage": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 회원 정보를 조회합니다
-         * @description 회원의 마이페이지 접근 시 정보 조회 (동호회 정보 포함)
-         */
-        get: operations["getMemberInfo"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 동호회원 정지
+     * @description 동호회원의 활동을 정지시킵니다.
+     */
+    patch: operations["banClubMember"];
+    trace?: never;
+  };
+  "/v1/members/myPage": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members/is-club-member": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 회원이 동호회에 가입되어있는지 확인합니다
-         * @description 회원이 동호회에 가입되어있는지 확인합니다
-         */
-        get: operations["getMemberIsClubMember"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 회원 정보를 조회합니다
+     * @description 회원의 마이페이지 접근 시 정보 조회 (동호회 정보 포함)
+     */
+    get: operations["getMemberInfo"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/members/is-club-member": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/month": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 월별로 경기 일정을 조회합니다.
-         * @description 월별로 경기 일정을 리스트로 조회할 수 있습니다. 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
-         */
-        get: operations["getLeagueByMonth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 회원이 동호회에 가입되어있는지 확인합니다
+     * @description 회원이 동호회에 가입되어있는지 확인합니다
+     */
+    get: operations["getMemberIsClubMember"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/month": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/{clubId}/leagues/date": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 일자별로 경기 일정을 조회합니다.
-         * @description 일별로 경기 일정을 리스트로 조회할 수 있습니다. 검색 조건으로 날짜를 사용하며, 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
-         */
-        get: operations["getLeagueByDate"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 월별로 경기 일정을 조회합니다.
+     * @description 월별로 경기 일정을 리스트로 조회할 수 있습니다. 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
+     */
+    get: operations["getLeagueByMonth"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/{clubId}/leagues/date": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/clubs/search": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 검색 조건에 맞는 동호회 조회
-         * @description 검색 조건에 맞는 동호회를 조회합니다.
-         */
-        get: operations["clubSearch"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 일자별로 경기 일정을 조회합니다.
+     * @description 일별로 경기 일정을 리스트로 조회할 수 있습니다. 검색 조건으로 날짜를 사용하며, 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
+     */
+    get: operations["getLeagueByDate"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/clubs/search": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/members": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * 회원 탈퇴를 합니다
-         * @description 멤버 필드의 isDeleted 를 true 로 변경합니다
-         */
-        delete: operations["deleteMember"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 검색 조건에 맞는 동호회 조회
+     * @description 검색 조건에 맞는 동호회를 조회합니다.
+     */
+    get: operations["clubSearch"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/members": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * 회원 탈퇴를 합니다
+     * @description 멤버 필드의 isDeleted 를 true 로 변경합니다
+     */
+    delete: operations["deleteMember"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        /** @description 회원 요청 DTO */
-        MemberResponse: {
-            /**
-             * Format: int64
-             * @description 회원 id
-             * @example 1
-             */
-            member_id?: number;
-            /**
-             * @description 회원 역할
-             * @example AUTHORIZATION_USER
-             */
-            authorization?: string;
-            /**
-             * @description 회원 이름
-             * @example 이선우
-             */
-            name?: string;
-            /**
-             * @description oAuth 로그인 이메일
-             * @example qosle@naver.com
-             */
-            email?: string;
-            /**
-             * @description oAuth 제공 ID
-             * @example 1070449979547641023123
-             */
-            provider_id?: string;
-            /**
-             * @description oAuth 제공 이미지
-             * @example 1070449979547641023123
-             */
-            profile_image?: string;
-        };
-        ImageUploadRequest: {
-            /** Format: binary */
-            multipartFile?: string;
-        };
-        ClubCreateRequest: {
-            club_name?: string;
-            club_description: string;
-            club_image?: string;
-        };
-        ClubCreateResponse: {
-            /** Format: int64 */
-            club_id?: number;
-            club_name?: string;
-            club_description?: string;
-            club_image?: string;
-            /** Format: date-time */
-            created_at?: string;
-            /** Format: date-time */
-            modified_at?: string;
-        };
-        LeagueCreateRequest: {
-            /**
-             * @description 경기 이름
-             * @example 배드민턴 경기
-             */
-            league_name?: string;
-            /**
-             * @description 경기 설명
-             * @example 이 경기는 지역 예선 경기입니다.
-             */
-            description?: string;
-            /**
-             * @description 경기 장소
-             * @example 성동구 서울숲 체육센터
-             */
-            league_location?: string;
-            /**
-             * @description 최소 티어
-             * @example GOLD
-             * @enum {string}
-             */
-            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-            /**
-             * @description 경기 방식
-             * @example SINGLES
-             * @enum {string}
-             */
-            match_type?: "SINGLES" | "DOUBLES";
-            /**
-             * Format: date-time
-             * @description 경기 시작 날짜
-             */
-            league_at?: string;
-            /**
-             * Format: date-time
-             * @description 모집 마감 날짜
-             */
-            closed_at?: string;
-            /**
-             * Format: int32
-             * @description 참가 인원
-             * @example 16
-             */
-            player_count?: number;
-            /**
-             * @description 매칭 조건
-             * @example TIER
-             * @enum {string}
-             */
-            match_generation_type?: "RANDOM" | "TIER";
-        };
-        LeagueCreateResponse: {
-            /**
-             * @description 경기 이름
-             * @example 배드민턴 경기
-             */
-            league_name?: string;
-            /**
-             * @description 경기 설명
-             * @example 이 경기는 지역 예선 경기입니다.
-             */
-            description?: string;
-            /**
-             * @description 최소 티어
-             * @example GOLD
-             * @enum {string}
-             */
-            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-            /**
-             * @description 현재 경기 상태
-             * @example OPEN
-             * @enum {string}
-             */
-            status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-            /**
-             * @description 경기 방식
-             * @example SINGLE
-             * @enum {string}
-             */
-            match_type?: "SINGLES" | "DOUBLES";
-            /**
-             * Format: date-time
-             * @description 경기 시작 날짜
-             */
-            league_at?: string;
-            /**
-             * Format: date-time
-             * @description 모집 마감 날짜
-             */
-            closed_at?: string;
-            /**
-             * Format: int32
-             * @description 참가 인원
-             * @example 16
-             */
-            player_count?: number;
-            /**
-             * Format: date-time
-             * @description 생성 일자
-             */
-            created_at?: string;
-            /**
-             * Format: date-time
-             * @description 수정 일자
-             */
-            modified_at?: string;
-            /**
-             * @description 매칭 조건
-             * @example TIER
-             * @enum {string}
-             */
-            match_generation_type?: "RANDOM" | "TIER";
-        };
-        LeagueParticipantResponse: {
-            /** Format: int64 */
-            league_id?: number;
-            /** Format: int64 */
-            club_member_id?: number;
-            /** Format: date-time */
-            created_at?: string;
-            /** Format: date-time */
-            modified_at?: string;
-        };
-        DoublesMatchResponse: {
-            team1?: components["schemas"]["TeamResponse"];
-            team2?: components["schemas"]["TeamResponse"];
-        };
-        MatchResponse: {
-            /** Format: int64 */
-            match_id?: number;
-            /** Format: int64 */
-            league_id?: number;
-            /** @enum {string} */
-            match_type?: "SINGLES" | "DOUBLES";
-            singles_match?: components["schemas"]["SinglesMatchResponse"];
-            doubles_match?: components["schemas"]["DoublesMatchResponse"];
-        };
-        SinglesMatchResponse: {
-            participant1_name?: string;
-            participant1_image?: string;
-            participant2_name?: string;
-            participant2_image?: string;
-        };
-        TeamResponse: {
-            participant1_name?: string;
-            participant1_image?: string;
-            participant2_name?: string;
-            participant2_image?: string;
-        };
-        SetScoreUpdateRequest: {
-            /** Format: int32 */
-            score1?: number;
-            /** Format: int32 */
-            score2?: number;
-        };
-        SetScoreUpdateResponse: {
-            /** Format: int64 */
-            match_id?: number;
-            /** Format: int32 */
-            set_index?: number;
-            /** Format: int32 */
-            score1?: number;
-            /** Format: int32 */
-            score2?: number;
-            /** @enum {string} */
-            match_type?: "SINGLES" | "DOUBLES";
-        };
-        DoublesSetResponse: {
-            /** Format: int32 */
-            set_index?: number;
-            /** Format: int32 */
-            score1?: number;
-            /** Format: int32 */
-            score2?: number;
-        };
-        MatchDetailsResponse: {
-            /** Format: int64 */
-            match_id?: number;
-            /** Format: int64 */
-            league_id?: number;
-            /** @enum {string} */
-            match_type?: "SINGLES" | "DOUBLES";
-            singles_match?: components["schemas"]["SinglesMatchResponse"];
-            doubles_match?: components["schemas"]["DoublesMatchResponse"];
-            singles_sets?: components["schemas"]["SinglesSetResponse"][];
-            doubles_sets?: components["schemas"]["DoublesSetResponse"][];
-        };
-        SinglesSetResponse: {
-            /** Format: int32 */
-            set_index?: number;
-            /** Format: int32 */
-            score1?: number;
-            /** Format: int32 */
-            score2?: number;
-        };
-        ClubMemberJoinResponse: {
-            /** Format: int64 */
-            club_member_id?: number;
-            role?: string;
-        };
-        ClubUpdateRequest: {
-            club_name: string;
-            club_description: string;
-            club_image?: string;
-        };
-        ClubUpdateResponse: {
-            /** Format: int64 */
-            club_id?: number;
-            club_name?: string;
-            club_description?: string;
-            club_image?: string;
-            /** Format: date-time */
-            created_at?: string;
-            /** Format: date-time */
-            modified_at?: string;
-        };
-        LeagueUpdateRequest: {
-            /**
-             * @description 경기 이름
-             * @example 배드민턴 경기
-             */
-            league_name?: string;
-            /**
-             * @description 경기 설명
-             * @example 이 경기는 지역 예선 경기입니다.
-             */
-            description?: string;
-            /**
-             * @description 경기 장소
-             * @example 성동구 서울숲 체육센터
-             */
-            league_location?: string;
-            /**
-             * @description 최소 티어
-             * @example GOLD
-             * @enum {string}
-             */
-            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-            /**
-             * @description 경기 방식
-             * @example SINGLES
-             * @enum {string}
-             */
-            match_type?: "SINGLES" | "DOUBLES";
-            /**
-             * Format: date-time
-             * @description 경기 시작 날짜
-             */
-            league_at?: string;
-            /**
-             * Format: date-time
-             * @description 모집 마감 날짜
-             */
-            closed_at?: string;
-            /**
-             * Format: int32
-             * @description 참가 인원
-             * @example 16
-             */
-            player_count?: number;
-            /**
-             * @description 매칭 조건
-             * @example TIER
-             * @enum {string}
-             */
-            match_generation_type?: "RANDOM" | "TIER";
-        };
-        LeagueStatusUpdateResponse: {
-            /**
-             * Format: int64
-             * @description 특정 경기 아이디
-             */
-            league_id?: number;
-            /**
-             * @description 경기 이름
-             * @example 배드민턴 경기
-             */
-            league_name?: string;
-            /**
-             * @description 경기 설명
-             * @example 이 경기는 지역 예선 경기입니다.
-             */
-            description?: string;
-            /**
-             * @description 최소 티어
-             * @example GOLD
-             * @enum {string}
-             */
-            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-            /**
-             * @description 현재 경기 상태
-             * @example OPEN
-             * @enum {string}
-             */
-            league_status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-            /**
-             * @description 경기 방식
-             * @example SINGLE
-             * @enum {string}
-             */
-            match_type?: "SINGLES" | "DOUBLES";
-            /**
-             * Format: date-time
-             * @description 경기 시작 날짜
-             */
-            league_at?: string;
-            /**
-             * Format: date-time
-             * @description 모집 마감 날짜
-             */
-            closed_at?: string;
-            /**
-             * Format: int32
-             * @description 참가 인원
-             * @example 16
-             */
-            player_count?: number;
-            /**
-             * Format: date-time
-             * @description 수정 일자
-             */
-            modified_at?: string;
-            /**
-             * @description 매칭 조건
-             * @example TIER
-             * @enum {string}
-             */
-            match_generation_type?: "RANDOM" | "TIER";
-        };
-        ClubMemberRoleUpdateRequest: {
-            /** @enum {string} */
-            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-        };
-        ClubMemberResponse: {
-            /** Format: int64 */
-            club_member_id?: number;
-            image?: string;
-            name?: string;
-            /** @enum {string} */
-            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-            /** @enum {string} */
-            tier?: "GOLD" | "SILVER" | "BRONZE";
-            league_record_info_response?: components["schemas"]["LeagueRecordInfoResponse"];
-        };
-        LeagueRecordInfoResponse: {
-            /** Format: int32 */
-            win_count?: number;
-            /** Format: int32 */
-            lose_count?: number;
-            /** Format: int32 */
-            draw_count?: number;
-            /** Format: int32 */
-            match_count?: number;
-        };
-        ClubMemberExpelRequest: {
-            expel_reason?: string;
-        };
-        clubMemberBanRecordResponse: {
-            /** @enum {string} */
-            banned_type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
-            banned_reason?: string;
-            /** Format: int64 */
-            club_member_id?: number;
-            is_active?: boolean;
-            /** Format: date-time */
-            end_date?: string;
-        };
-        ClubMemberBanRequest: {
-            /** @enum {string} */
-            type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
-            banned_reason?: string;
-        };
-        /** @description ClubMember information */
-        ClubMemberMyPageResponse: {
-            /**
-             * Format: int64
-             * @description Club ID
-             * @example 1
-             */
-            club_id?: number;
-            /**
-             * Format: int64
-             * @description Club member ID
-             * @example 1
-             */
-            club_member_id?: number;
-            /**
-             * @description Club name
-             * @example 배드민턴 동호회
-             */
-            club_name?: string;
-            /**
-             * @description Member role
-             * @example ROLE_USER
-             * @enum {string}
-             */
-            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-            /**
-             * @description ClubMember Tier
-             * @example GOLD
-             * @enum {string}
-             */
-            tier?: "GOLD" | "SILVER" | "BRONZE";
-        };
-        /** @description Unified member response */
-        MemberMyPageResponse: {
-            /**
-             * Format: int64
-             * @description Member ID
-             * @example 1
-             */
-            member_id?: number;
-            /**
-             * @description Member name
-             * @example 김철수
-             */
-            name?: string;
-            /**
-             * @description Email
-             * @example example@email.com
-             */
-            email?: string;
-            /**
-             * @description Profile image URL
-             * @example https://example.com/profile.jpg
-             */
-            profile_image?: string;
-            club_member_my_page_response?: components["schemas"]["ClubMemberMyPageResponse"];
-            league_record_info?: components["schemas"]["LeagueRecordInfoResponse"];
-        };
-        MemberIsClubMemberResponse: {
-            is_club_member?: boolean;
-            /** @enum {string} */
-            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-            /** Format: int64 */
-            club_id?: number;
-        };
-        ClubCardResponse: {
-            /** Format: int64 */
-            club_id?: number;
-            club_name?: string;
-            club_description?: string;
-            club_image?: string;
-            /** Format: date-time */
-            created_at?: string;
-            /** Format: date-time */
-            modified_at?: string;
-            club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
-        };
-        ClubMemberCountByTier: {
-            /** Format: int64 */
-            gold_club_member_count?: number;
-            /** Format: int64 */
-            silver_club_member_count?: number;
-            /** Format: int64 */
-            bronze_club_member_count?: number;
-        };
-        PageClubCardResponse: {
-            /** Format: int32 */
-            total_pages?: number;
-            /** Format: int64 */
-            total_elements?: number;
-            first?: boolean;
-            last?: boolean;
-            /** Format: int32 */
-            size?: number;
-            content?: components["schemas"]["ClubCardResponse"][];
-            /** Format: int32 */
-            number?: number;
-            sort?: components["schemas"]["SortObject"][];
-            /** Format: int32 */
-            number_of_elements?: number;
-            pageable?: components["schemas"]["PageableObject"];
-            empty?: boolean;
-        };
-        PageableObject: {
-            /** Format: int64 */
-            offset?: number;
-            sort?: components["schemas"]["SortObject"][];
-            paged?: boolean;
-            /** Format: int32 */
-            page_number?: number;
-            /** Format: int32 */
-            page_size?: number;
-            unpaged?: boolean;
-        };
-        SortObject: {
-            direction?: string;
-            null_handling?: string;
-            ascending?: boolean;
-            property?: string;
-            ignore_case?: boolean;
-        };
-        ClubDetailsResponse: {
-            /** Format: int64 */
-            club_id?: number;
-            club_name?: string;
-            club_description?: string;
-            club_image?: string;
-            club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
-            /** Format: int32 */
-            club_member_count?: number;
-            /** Format: date-time */
-            created_at?: string;
-            is_club_member?: boolean;
-        };
-        LeagueAndParticipantResponse: {
-            /**
-             * Format: int64
-             * @description 경기 아이디
-             */
-            league_id?: number;
-            /**
-             * @description 경기 이름
-             * @example 배드민턴 경기
-             */
-            league_name?: string;
-            /**
-             * @description 경기 설명
-             * @example 이 경기는 지역 예선 경기입니다.
-             */
-            description?: string;
-            /**
-             * @description 최소 티어
-             * @example GOLD
-             * @enum {string}
-             */
-            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-            /**
-             * @description 현재 경기 상태
-             * @example OPEN
-             * @enum {string}
-             */
-            status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-            /**
-             * @description 경기 방식
-             * @example SINGLE
-             * @enum {string}
-             */
-            match_type?: "SINGLES" | "DOUBLES";
-            /**
-             * Format: date-time
-             * @description 경기 시작 날짜
-             */
-            league_at?: string;
-            /**
-             * Format: date-time
-             * @description 모집 마감 날짜
-             */
-            closed_at?: string;
-            /**
-             * Format: int32
-             * @description 참가 제한 인원
-             * @example 16
-             */
-            player_limit_count?: number;
-            /**
-             * Format: date-time
-             * @description 생성 일자
-             */
-            created_at?: string;
-            /**
-             * Format: date-time
-             * @description 수정 일자
-             */
-            modified_at?: string;
-            /**
-             * @description 매칭 조건
-             * @example RANDOM
-             * @enum {string}
-             */
-            match_generation_type?: "RANDOM" | "TIER";
-            /**
-             * Format: int32
-             * @description 현재 참여 인원
-             * @example 0
-             */
-            player_count?: number;
-        };
-        LeagueReadResponse: {
-            /**
-             * Format: int64
-             * @description 경기 아이디
-             */
-            league_id?: number;
-            /**
-             * @description 경기 이름
-             * @example 배드민턴 경기
-             */
-            league_name?: string;
-            /**
-             * @description 현재 경기 상태
-             * @example OPEN
-             * @enum {string}
-             */
-            status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-            /**
-             * Format: date-time
-             * @description 경기 시작 날짜
-             */
-            league_at?: string;
-            /**
-             * Format: int32
-             * @description 참가 인원
-             * @example 16
-             */
-            player_count?: number;
-        };
-        LeagueByDateResponse: {
-            /** Format: int64 */
-            league_id?: number;
-            /** Format: date-time */
-            league_at?: string;
-            league_name?: string;
-            /** @enum {string} */
-            match_type?: "SINGLES" | "DOUBLES";
-            /** @enum {string} */
-            required_tier?: "GOLD" | "SILVER" | "BRONZE";
-            /** Format: date-time */
-            closed_at?: string;
-            /** Format: int32 */
-            player_limit_count?: number;
-            /** Format: int32 */
-            recruited_member_count?: number;
-        };
-        /** @description 회원 삭제 responseDto */
-        MemberDeleteResponse: {
-            /**
-             * Format: int64
-             * @description 멤버 id
-             * @example 1
-             */
-            member_id?: number;
-            /**
-             * @description 삭제 여부
-             * @example true
-             */
-            is_deleted?: boolean;
-        };
-        ClubDeleteResponse: {
-            /** Format: int64 */
-            club_id?: number;
-            is_club_deleted?: boolean;
-        };
-        LeagueParticipationCancelResponse: {
-            /** Format: int64 */
-            league_id?: number;
-            /** Format: int64 */
-            club_member_id?: number;
-            /** Format: date-time */
-            created_at?: string;
-            /** Format: date-time */
-            deleted_at?: string;
-        };
+  schemas: {
+    /** @description 회원 요청 DTO */
+    MemberResponse: {
+      /**
+       * Format: int64
+       * @description 회원 id
+       * @example 1
+       */
+      member_id?: number;
+      /**
+       * @description 회원 역할
+       * @example AUTHORIZATION_USER
+       */
+      authorization?: string;
+      /**
+       * @description 회원 이름
+       * @example 이선우
+       */
+      name?: string;
+      /**
+       * @description oAuth 로그인 이메일
+       * @example qosle@naver.com
+       */
+      email?: string;
+      /**
+       * @description oAuth 제공 ID
+       * @example 1070449979547641023123
+       */
+      provider_id?: string;
+      /**
+       * @description oAuth 제공 이미지
+       * @example 1070449979547641023123
+       */
+      profile_image?: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    ImageUploadRequest: {
+      /** Format: binary */
+      multipartFile?: string;
+    };
+    ClubCreateRequest: {
+      club_name?: string;
+      club_description: string;
+      club_image?: string;
+    };
+    ClubCreateResponse: {
+      /** Format: int64 */
+      club_id?: number;
+      club_name?: string;
+      club_description?: string;
+      club_image?: string;
+      /** Format: date-time */
+      created_at?: string;
+      /** Format: date-time */
+      modified_at?: string;
+    };
+    LeagueCreateRequest: {
+      /**
+       * @description 경기 이름
+       * @example 배드민턴 경기
+       */
+      league_name?: string;
+      /**
+       * @description 경기 설명
+       * @example 이 경기는 지역 예선 경기입니다.
+       */
+      description?: string;
+      /**
+       * @description 경기 장소
+       * @example 성동구 서울숲 체육센터
+       */
+      league_location?: string;
+      /**
+       * @description 최소 티어
+       * @example GOLD
+       * @enum {string}
+       */
+      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+      /**
+       * @description 경기 방식
+       * @example SINGLES
+       * @enum {string}
+       */
+      match_type?: "SINGLES" | "DOUBLES";
+      /**
+       * Format: date-time
+       * @description 경기 시작 날짜
+       */
+      league_at?: string;
+      /**
+       * Format: date-time
+       * @description 모집 마감 날짜
+       */
+      closed_at?: string;
+      /**
+       * Format: int32
+       * @description 참가 인원
+       * @example 16
+       */
+      player_count?: number;
+      /**
+       * @description 매칭 조건
+       * @example TIER
+       * @enum {string}
+       */
+      match_generation_type?: "RANDOM" | "TIER";
+    };
+    LeagueCreateResponse: {
+      /**
+       * @description 경기 이름
+       * @example 배드민턴 경기
+       */
+      league_name?: string;
+      /**
+       * @description 경기 설명
+       * @example 이 경기는 지역 예선 경기입니다.
+       */
+      description?: string;
+      /**
+       * @description 최소 티어
+       * @example GOLD
+       * @enum {string}
+       */
+      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+      /**
+       * @description 현재 경기 상태
+       * @example OPEN
+       * @enum {string}
+       */
+      status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+      /**
+       * @description 경기 방식
+       * @example SINGLE
+       * @enum {string}
+       */
+      match_type?: "SINGLES" | "DOUBLES";
+      /**
+       * Format: date-time
+       * @description 경기 시작 날짜
+       */
+      league_at?: string;
+      /**
+       * Format: date-time
+       * @description 모집 마감 날짜
+       */
+      closed_at?: string;
+      /**
+       * Format: int32
+       * @description 참가 인원
+       * @example 16
+       */
+      player_count?: number;
+      /**
+       * Format: date-time
+       * @description 생성 일자
+       */
+      created_at?: string;
+      /**
+       * Format: date-time
+       * @description 수정 일자
+       */
+      modified_at?: string;
+      /**
+       * @description 매칭 조건
+       * @example TIER
+       * @enum {string}
+       */
+      match_generation_type?: "RANDOM" | "TIER";
+    };
+    LeagueParticipantResponse: {
+      /** Format: int64 */
+      league_id?: number;
+      /** Format: int64 */
+      club_member_id?: number;
+      /** Format: date-time */
+      created_at?: string;
+      /** Format: date-time */
+      modified_at?: string;
+    };
+    DoublesMatchResponse: {
+      team1?: components["schemas"]["TeamResponse"];
+      team2?: components["schemas"]["TeamResponse"];
+    };
+    MatchResponse: {
+      /** Format: int64 */
+      match_id?: number;
+      /** Format: int64 */
+      league_id?: number;
+      /** @enum {string} */
+      match_type?: "SINGLES" | "DOUBLES";
+      singles_match?: components["schemas"]["SinglesMatchResponse"];
+      doubles_match?: components["schemas"]["DoublesMatchResponse"];
+    };
+    SinglesMatchResponse: {
+      participant1_name?: string;
+      participant1_image?: string;
+      participant2_name?: string;
+      participant2_image?: string;
+    };
+    TeamResponse: {
+      participant1_name?: string;
+      participant1_image?: string;
+      participant2_name?: string;
+      participant2_image?: string;
+    };
+    SetScoreUpdateRequest: {
+      /** Format: int32 */
+      score1?: number;
+      /** Format: int32 */
+      score2?: number;
+    };
+    SetScoreUpdateResponse: {
+      /** Format: int64 */
+      match_id?: number;
+      /** Format: int32 */
+      set_index?: number;
+      /** Format: int32 */
+      score1?: number;
+      /** Format: int32 */
+      score2?: number;
+      /** @enum {string} */
+      match_type?: "SINGLES" | "DOUBLES";
+    };
+    DoublesSetResponse: {
+      /** Format: int32 */
+      set_index?: number;
+      /** Format: int32 */
+      score1?: number;
+      /** Format: int32 */
+      score2?: number;
+    };
+    MatchDetailsResponse: {
+      /** Format: int64 */
+      match_id?: number;
+      /** Format: int64 */
+      league_id?: number;
+      /** @enum {string} */
+      match_type?: "SINGLES" | "DOUBLES";
+      singles_match?: components["schemas"]["SinglesMatchResponse"];
+      doubles_match?: components["schemas"]["DoublesMatchResponse"];
+      singles_sets?: components["schemas"]["SinglesSetResponse"][];
+      doubles_sets?: components["schemas"]["DoublesSetResponse"][];
+    };
+    SinglesSetResponse: {
+      /** Format: int32 */
+      set_index?: number;
+      /** Format: int32 */
+      score1?: number;
+      /** Format: int32 */
+      score2?: number;
+    };
+    ClubMemberJoinResponse: {
+      /** Format: int64 */
+      club_member_id?: number;
+      role?: string;
+    };
+    ClubUpdateRequest: {
+      club_name: string;
+      club_description: string;
+      club_image?: string;
+    };
+    ClubUpdateResponse: {
+      /** Format: int64 */
+      club_id?: number;
+      club_name?: string;
+      club_description?: string;
+      club_image?: string;
+      /** Format: date-time */
+      created_at?: string;
+      /** Format: date-time */
+      modified_at?: string;
+    };
+    LeagueUpdateRequest: {
+      /**
+       * @description 경기 이름
+       * @example 배드민턴 경기
+       */
+      league_name?: string;
+      /**
+       * @description 경기 설명
+       * @example 이 경기는 지역 예선 경기입니다.
+       */
+      description?: string;
+      /**
+       * @description 경기 장소
+       * @example 성동구 서울숲 체육센터
+       */
+      league_location?: string;
+      /**
+       * @description 최소 티어
+       * @example GOLD
+       * @enum {string}
+       */
+      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+      /**
+       * @description 경기 방식
+       * @example SINGLES
+       * @enum {string}
+       */
+      match_type?: "SINGLES" | "DOUBLES";
+      /**
+       * Format: date-time
+       * @description 경기 시작 날짜
+       */
+      league_at?: string;
+      /**
+       * Format: date-time
+       * @description 모집 마감 날짜
+       */
+      closed_at?: string;
+      /**
+       * Format: int32
+       * @description 참가 인원
+       * @example 16
+       */
+      player_count?: number;
+      /**
+       * @description 매칭 조건
+       * @example TIER
+       * @enum {string}
+       */
+      match_generation_type?: "RANDOM" | "TIER";
+    };
+    LeagueStatusUpdateResponse: {
+      /**
+       * Format: int64
+       * @description 특정 경기 아이디
+       */
+      league_id?: number;
+      /**
+       * @description 경기 이름
+       * @example 배드민턴 경기
+       */
+      league_name?: string;
+      /**
+       * @description 경기 설명
+       * @example 이 경기는 지역 예선 경기입니다.
+       */
+      description?: string;
+      /**
+       * @description 최소 티어
+       * @example GOLD
+       * @enum {string}
+       */
+      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+      /**
+       * @description 현재 경기 상태
+       * @example OPEN
+       * @enum {string}
+       */
+      league_status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+      /**
+       * @description 경기 방식
+       * @example SINGLE
+       * @enum {string}
+       */
+      match_type?: "SINGLES" | "DOUBLES";
+      /**
+       * Format: date-time
+       * @description 경기 시작 날짜
+       */
+      league_at?: string;
+      /**
+       * Format: date-time
+       * @description 모집 마감 날짜
+       */
+      closed_at?: string;
+      /**
+       * Format: int32
+       * @description 참가 인원
+       * @example 16
+       */
+      player_count?: number;
+      /**
+       * Format: date-time
+       * @description 수정 일자
+       */
+      modified_at?: string;
+      /**
+       * @description 매칭 조건
+       * @example TIER
+       * @enum {string}
+       */
+      match_generation_type?: "RANDOM" | "TIER";
+    };
+    ClubMemberRoleUpdateRequest: {
+      /** @enum {string} */
+      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+    };
+    ClubMemberResponse: {
+      /** Format: int64 */
+      club_member_id?: number;
+      image?: string;
+      name?: string;
+      /** @enum {string} */
+      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+      /** @enum {string} */
+      tier?: "GOLD" | "SILVER" | "BRONZE";
+      league_record_info_response?: components["schemas"]["LeagueRecordInfoResponse"];
+    };
+    LeagueRecordInfoResponse: {
+      /** Format: int32 */
+      win_count?: number;
+      /** Format: int32 */
+      lose_count?: number;
+      /** Format: int32 */
+      draw_count?: number;
+      /** Format: int32 */
+      match_count?: number;
+    };
+    ClubMemberExpelRequest: {
+      expel_reason?: string;
+    };
+    clubMemberBanRecordResponse: {
+      /** @enum {string} */
+      banned_type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
+      banned_reason?: string;
+      /** Format: int64 */
+      club_member_id?: number;
+      is_active?: boolean;
+      /** Format: date-time */
+      end_date?: string;
+    };
+    ClubMemberBanRequest: {
+      /** @enum {string} */
+      type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
+      banned_reason?: string;
+    };
+    /** @description ClubMember information */
+    ClubMemberMyPageResponse: {
+      /**
+       * Format: int64
+       * @description Club ID
+       * @example 1
+       */
+      club_id?: number;
+      /**
+       * Format: int64
+       * @description Club member ID
+       * @example 1
+       */
+      club_member_id?: number;
+      /**
+       * @description Club name
+       * @example 배드민턴 동호회
+       */
+      club_name?: string;
+      /**
+       * @description Member role
+       * @example ROLE_USER
+       * @enum {string}
+       */
+      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+      /**
+       * @description ClubMember Tier
+       * @example GOLD
+       * @enum {string}
+       */
+      tier?: "GOLD" | "SILVER" | "BRONZE";
+    };
+    /** @description Unified member response */
+    MemberMyPageResponse: {
+      /**
+       * Format: int64
+       * @description Member ID
+       * @example 1
+       */
+      member_id?: number;
+      /**
+       * @description Member name
+       * @example 김철수
+       */
+      name?: string;
+      /**
+       * @description Email
+       * @example example@email.com
+       */
+      email?: string;
+      /**
+       * @description Profile image URL
+       * @example https://example.com/profile.jpg
+       */
+      profile_image?: string;
+      club_member_my_page_response?: components["schemas"]["ClubMemberMyPageResponse"];
+      league_record_info?: components["schemas"]["LeagueRecordInfoResponse"];
+    };
+    MemberIsClubMemberResponse: {
+      is_club_member?: boolean;
+      /** @enum {string} */
+      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+      /** Format: int64 */
+      club_id?: number;
+    };
+    ClubCardResponse: {
+      /** Format: int64 */
+      club_id?: number;
+      club_name?: string;
+      club_description?: string;
+      club_image?: string;
+      /** Format: date-time */
+      created_at?: string;
+      /** Format: date-time */
+      modified_at?: string;
+      club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
+    };
+    ClubMemberCountByTier: {
+      /** Format: int64 */
+      gold_club_member_count?: number;
+      /** Format: int64 */
+      silver_club_member_count?: number;
+      /** Format: int64 */
+      bronze_club_member_count?: number;
+    };
+    PageClubCardResponse: {
+      /** Format: int32 */
+      total_pages?: number;
+      /** Format: int64 */
+      total_elements?: number;
+      first?: boolean;
+      last?: boolean;
+      /** Format: int32 */
+      size?: number;
+      content?: components["schemas"]["ClubCardResponse"][];
+      /** Format: int32 */
+      number?: number;
+      sort?: components["schemas"]["SortObject"][];
+      /** Format: int32 */
+      number_of_elements?: number;
+      pageable?: components["schemas"]["PageableObject"];
+      empty?: boolean;
+    };
+    PageableObject: {
+      /** Format: int64 */
+      offset?: number;
+      sort?: components["schemas"]["SortObject"][];
+      paged?: boolean;
+      /** Format: int32 */
+      page_number?: number;
+      /** Format: int32 */
+      page_size?: number;
+      unpaged?: boolean;
+    };
+    SortObject: {
+      direction?: string;
+      null_handling?: string;
+      ascending?: boolean;
+      property?: string;
+      ignore_case?: boolean;
+    };
+    ClubDetailsResponse: {
+      /** Format: int64 */
+      club_id?: number;
+      club_name?: string;
+      club_description?: string;
+      club_image?: string;
+      club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
+      /** Format: int32 */
+      club_member_count?: number;
+      /** Format: date-time */
+      created_at?: string;
+      is_club_member?: boolean;
+    };
+    LeagueAndParticipantResponse: {
+      /**
+       * Format: int64
+       * @description 경기 아이디
+       */
+      league_id?: number;
+      /**
+       * @description 경기 이름
+       * @example 배드민턴 경기
+       */
+      league_name?: string;
+      /**
+       * @description 경기 설명
+       * @example 이 경기는 지역 예선 경기입니다.
+       */
+      description?: string;
+      /**
+       * @description 최소 티어
+       * @example GOLD
+       * @enum {string}
+       */
+      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+      /**
+       * @description 현재 경기 상태
+       * @example OPEN
+       * @enum {string}
+       */
+      status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+      /**
+       * @description 경기 방식
+       * @example SINGLE
+       * @enum {string}
+       */
+      match_type?: "SINGLES" | "DOUBLES";
+      /**
+       * Format: date-time
+       * @description 경기 시작 날짜
+       */
+      league_at?: string;
+      /**
+       * Format: date-time
+       * @description 모집 마감 날짜
+       */
+      closed_at?: string;
+      /**
+       * Format: int32
+       * @description 참가 제한 인원
+       * @example 16
+       */
+      player_limit_count?: number;
+      /**
+       * Format: date-time
+       * @description 생성 일자
+       */
+      created_at?: string;
+      /**
+       * Format: date-time
+       * @description 수정 일자
+       */
+      modified_at?: string;
+      /**
+       * @description 매칭 조건
+       * @example RANDOM
+       * @enum {string}
+       */
+      match_generation_type?: "RANDOM" | "TIER";
+      /**
+       * Format: int32
+       * @description 현재 참여 인원
+       * @example 0
+       */
+      player_count?: number;
+    };
+    LeagueReadResponse: {
+      /**
+       * Format: int64
+       * @description 경기 아이디
+       */
+      league_id?: number;
+      /**
+       * @description 경기 이름
+       * @example 배드민턴 경기
+       */
+      league_name?: string;
+      /**
+       * @description 현재 경기 상태
+       * @example OPEN
+       * @enum {string}
+       */
+      status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+      /**
+       * Format: date-time
+       * @description 경기 시작 날짜
+       */
+      league_at?: string;
+      /**
+       * Format: int32
+       * @description 참가 인원
+       * @example 16
+       */
+      player_count?: number;
+    };
+    LeagueByDateResponse: {
+      /** Format: int64 */
+      league_id?: number;
+      /** Format: date-time */
+      league_at?: string;
+      league_name?: string;
+      /** @enum {string} */
+      match_type?: "SINGLES" | "DOUBLES";
+      /** @enum {string} */
+      required_tier?: "GOLD" | "SILVER" | "BRONZE";
+      /** Format: date-time */
+      closed_at?: string;
+      /** Format: int32 */
+      player_limit_count?: number;
+      /** Format: int32 */
+      recruited_member_count?: number;
+    };
+    /** @description 회원 삭제 responseDto */
+    MemberDeleteResponse: {
+      /**
+       * Format: int64
+       * @description 멤버 id
+       * @example 1
+       */
+      member_id?: number;
+      /**
+       * @description 삭제 여부
+       * @example true
+       */
+      is_deleted?: boolean;
+    };
+    ClubDeleteResponse: {
+      /** Format: int64 */
+      club_id?: number;
+      is_club_deleted?: boolean;
+    };
+    LeagueParticipationCancelResponse: {
+      /** Format: int64 */
+      league_id?: number;
+      /** Format: int64 */
+      club_member_id?: number;
+      /** Format: date-time */
+      created_at?: string;
+      /** Format: date-time */
+      deleted_at?: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    updateProfileImage: {
-        parameters: {
-            query: {
-                imageUrl: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MemberResponse"];
-                };
-            };
-        };
+  updateProfileImage: {
+    parameters: {
+      query: {
+        imageUrl: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    uploadProfileImage: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "multipart/form-data": components["schemas"]["ImageUploadRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["MemberResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-        };
+      };
     };
-    addWin: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-        };
+  };
+  uploadProfileImage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    refreshToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["ImageUploadRequest"];
+      };
     };
-    addLose: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
+        content: {
+          "*/*": string;
         };
+      };
     };
-    logout: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-        };
+  };
+  addWin: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    readAllClub: {
-        parameters: {
-            query?: {
-                page?: number;
-                size?: number;
-                sort?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PageClubCardResponse"];
-                };
-            };
+        content: {
+          "*/*": string;
         };
+      };
     };
-    createClub: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ClubCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ClubCreateResponse"];
-                };
-            };
-        };
+  };
+  refreshToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    createLeague: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LeagueCreateRequest"];
-            };
+        content: {
+          "*/*": Record<string, never>;
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueCreateResponse"];
-                };
-            };
-        };
+      };
     };
-    participateInLeague: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueParticipantResponse"];
-                };
-            };
-        };
+  };
+  addLose: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    cancelLeagueParticipation: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueParticipationCancelResponse"];
-                };
-            };
+        content: {
+          "*/*": string;
         };
+      };
     };
-    getMatches: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MatchResponse"][];
-                };
-            };
-        };
+  };
+  logout: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    makeMatches: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MatchResponse"][];
-                };
-            };
+        content: {
+          "*/*": string;
         };
+      };
     };
-    updateSetsScore: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-                matchId: number;
-                setIndex: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SetScoreUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SetScoreUpdateResponse"];
-                };
-            };
-        };
+  };
+  readAllClub: {
+    parameters: {
+      query?: {
+        page?: number;
+        size?: number;
+        sort?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    makeMatchesDetails: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MatchDetailsResponse"][];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["PageClubCardResponse"];
         };
+      };
     };
-    getClubMembersInClub: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": {
-                        [key: string]: components["schemas"]["ClubMemberResponse"][];
-                    };
-                };
-            };
-        };
+  };
+  createClub: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    joinClub: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 동호회 ID
-                 * @example 1
-                 */
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ClubMemberJoinResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ClubCreateRequest"];
+      };
     };
-    saveImage: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "multipart/form-data": components["schemas"]["ImageUploadRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["ClubCreateResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-        };
+      };
     };
-    readClub: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ClubDetailsResponse"];
-                };
-            };
-        };
+  };
+  createLeague: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
     };
-    deleteClub: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ClubDeleteResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LeagueCreateRequest"];
+      };
     };
-    updateClub: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ClubUpdateRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["LeagueCreateResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ClubUpdateResponse"];
-                };
-            };
-        };
+      };
     };
-    leagueRead: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueAndParticipantResponse"];
-                };
-            };
-        };
+  };
+  participateInLeague: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
     };
-    deleteLeague: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": "CONTINUE" | "SWITCHING_PROTOCOLS" | "PROCESSING" | "EARLY_HINTS" | "CHECKPOINT" | "OK" | "CREATED" | "ACCEPTED" | "NON_AUTHORITATIVE_INFORMATION" | "NO_CONTENT" | "RESET_CONTENT" | "PARTIAL_CONTENT" | "MULTI_STATUS" | "ALREADY_REPORTED" | "IM_USED" | "MULTIPLE_CHOICES" | "MOVED_PERMANENTLY" | "FOUND" | "MOVED_TEMPORARILY" | "SEE_OTHER" | "NOT_MODIFIED" | "USE_PROXY" | "TEMPORARY_REDIRECT" | "PERMANENT_REDIRECT" | "BAD_REQUEST" | "UNAUTHORIZED" | "PAYMENT_REQUIRED" | "FORBIDDEN" | "NOT_FOUND" | "METHOD_NOT_ALLOWED" | "NOT_ACCEPTABLE" | "PROXY_AUTHENTICATION_REQUIRED" | "REQUEST_TIMEOUT" | "CONFLICT" | "GONE" | "LENGTH_REQUIRED" | "PRECONDITION_FAILED" | "PAYLOAD_TOO_LARGE" | "REQUEST_ENTITY_TOO_LARGE" | "URI_TOO_LONG" | "REQUEST_URI_TOO_LONG" | "UNSUPPORTED_MEDIA_TYPE" | "REQUESTED_RANGE_NOT_SATISFIABLE" | "EXPECTATION_FAILED" | "I_AM_A_TEAPOT" | "INSUFFICIENT_SPACE_ON_RESOURCE" | "METHOD_FAILURE" | "DESTINATION_LOCKED" | "UNPROCESSABLE_ENTITY" | "LOCKED" | "FAILED_DEPENDENCY" | "TOO_EARLY" | "UPGRADE_REQUIRED" | "PRECONDITION_REQUIRED" | "TOO_MANY_REQUESTS" | "REQUEST_HEADER_FIELDS_TOO_LARGE" | "UNAVAILABLE_FOR_LEGAL_REASONS" | "INTERNAL_SERVER_ERROR" | "NOT_IMPLEMENTED" | "BAD_GATEWAY" | "SERVICE_UNAVAILABLE" | "GATEWAY_TIMEOUT" | "HTTP_VERSION_NOT_SUPPORTED" | "VARIANT_ALSO_NEGOTIATES" | "INSUFFICIENT_STORAGE" | "LOOP_DETECTED" | "BANDWIDTH_LIMIT_EXCEEDED" | "NOT_EXTENDED" | "NETWORK_AUTHENTICATION_REQUIRED";
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["LeagueParticipantResponse"];
         };
+      };
     };
-    updateLeague: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                clubId: number;
-                leagueId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LeagueUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueStatusUpdateResponse"];
-                };
-            };
-        };
+  };
+  cancelLeagueParticipation: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
     };
-    updateClubMemberRole: {
-        parameters: {
-            query: {
-                clubMemberId: number;
-            };
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ClubMemberRoleUpdateRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["LeagueParticipationCancelResponse"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ClubMemberResponse"];
-                };
-            };
-        };
+      };
     };
-    expelClubMember: {
-        parameters: {
-            query: {
-                clubMemberId: number;
-            };
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ClubMemberExpelRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["clubMemberBanRecordResponse"];
-                };
-            };
-        };
+  };
+  getMatches: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
     };
-    banClubMember: {
-        parameters: {
-            query: {
-                clubMemberId: number;
-            };
-            header?: never;
-            path: {
-                clubId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ClubMemberBanRequest"];
-            };
+        content: {
+          "*/*": components["schemas"]["MatchResponse"][];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["clubMemberBanRecordResponse"];
-                };
-            };
-        };
+      };
     };
-    getMemberInfo: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MemberMyPageResponse"];
-                };
-            };
-        };
+  };
+  makeMatches: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
     };
-    getMemberIsClubMember: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MemberIsClubMemberResponse"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["MatchResponse"][];
         };
+      };
     };
-    getLeagueByMonth: {
-        parameters: {
-            query: {
-                /** @description 조회할 날짜, 'yyyy-MM' 형식으로 입력 */
-                date: string;
-            };
-            header?: never;
-            path: {
-                /** @description 조회할 클럽의 ID */
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueReadResponse"][];
-                };
-            };
-        };
+  };
+  updateSetsScore: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+        matchId: number;
+        setIndex: number;
+      };
+      cookie?: never;
     };
-    getLeagueByDate: {
-        parameters: {
-            query: {
-                /** @description 조회할 날짜, 'yyyy-MM-dd' 형식으로 입력 */
-                date: string;
-            };
-            header?: never;
-            path: {
-                /** @description 조회할 클럽의 ID */
-                clubId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["LeagueByDateResponse"][];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SetScoreUpdateRequest"];
+      };
     };
-    clubSearch: {
-        parameters: {
-            query?: {
-                page?: number;
-                size?: number;
-                sort?: string;
-                keyword?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PageClubCardResponse"];
-                };
-            };
+        content: {
+          "*/*": components["schemas"]["SetScoreUpdateResponse"];
         };
+      };
     };
-    deleteMember: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["MemberDeleteResponse"];
-                };
-            };
-        };
+  };
+  makeMatchesDetails: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
     };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MatchDetailsResponse"][];
+        };
+      };
+    };
+  };
+  getClubMembersInClub: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": {
+            [key: string]: components["schemas"]["ClubMemberResponse"][];
+          };
+        };
+      };
+    };
+  };
+  joinClub: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 동호회 ID
+         * @example 1
+         */
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ClubMemberJoinResponse"];
+        };
+      };
+    };
+  };
+  saveImage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["ImageUploadRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  readClub: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ClubDetailsResponse"];
+        };
+      };
+    };
+  };
+  deleteClub: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ClubDeleteResponse"];
+        };
+      };
+    };
+  };
+  updateClub: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ClubUpdateRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ClubUpdateResponse"];
+        };
+      };
+    };
+  };
+  leagueRead: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["LeagueAndParticipantResponse"];
+        };
+      };
+    };
+  };
+  deleteLeague: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*":
+            | "CONTINUE"
+            | "SWITCHING_PROTOCOLS"
+            | "PROCESSING"
+            | "EARLY_HINTS"
+            | "CHECKPOINT"
+            | "OK"
+            | "CREATED"
+            | "ACCEPTED"
+            | "NON_AUTHORITATIVE_INFORMATION"
+            | "NO_CONTENT"
+            | "RESET_CONTENT"
+            | "PARTIAL_CONTENT"
+            | "MULTI_STATUS"
+            | "ALREADY_REPORTED"
+            | "IM_USED"
+            | "MULTIPLE_CHOICES"
+            | "MOVED_PERMANENTLY"
+            | "FOUND"
+            | "MOVED_TEMPORARILY"
+            | "SEE_OTHER"
+            | "NOT_MODIFIED"
+            | "USE_PROXY"
+            | "TEMPORARY_REDIRECT"
+            | "PERMANENT_REDIRECT"
+            | "BAD_REQUEST"
+            | "UNAUTHORIZED"
+            | "PAYMENT_REQUIRED"
+            | "FORBIDDEN"
+            | "NOT_FOUND"
+            | "METHOD_NOT_ALLOWED"
+            | "NOT_ACCEPTABLE"
+            | "PROXY_AUTHENTICATION_REQUIRED"
+            | "REQUEST_TIMEOUT"
+            | "CONFLICT"
+            | "GONE"
+            | "LENGTH_REQUIRED"
+            | "PRECONDITION_FAILED"
+            | "PAYLOAD_TOO_LARGE"
+            | "REQUEST_ENTITY_TOO_LARGE"
+            | "URI_TOO_LONG"
+            | "REQUEST_URI_TOO_LONG"
+            | "UNSUPPORTED_MEDIA_TYPE"
+            | "REQUESTED_RANGE_NOT_SATISFIABLE"
+            | "EXPECTATION_FAILED"
+            | "I_AM_A_TEAPOT"
+            | "INSUFFICIENT_SPACE_ON_RESOURCE"
+            | "METHOD_FAILURE"
+            | "DESTINATION_LOCKED"
+            | "UNPROCESSABLE_ENTITY"
+            | "LOCKED"
+            | "FAILED_DEPENDENCY"
+            | "TOO_EARLY"
+            | "UPGRADE_REQUIRED"
+            | "PRECONDITION_REQUIRED"
+            | "TOO_MANY_REQUESTS"
+            | "REQUEST_HEADER_FIELDS_TOO_LARGE"
+            | "UNAVAILABLE_FOR_LEGAL_REASONS"
+            | "INTERNAL_SERVER_ERROR"
+            | "NOT_IMPLEMENTED"
+            | "BAD_GATEWAY"
+            | "SERVICE_UNAVAILABLE"
+            | "GATEWAY_TIMEOUT"
+            | "HTTP_VERSION_NOT_SUPPORTED"
+            | "VARIANT_ALSO_NEGOTIATES"
+            | "INSUFFICIENT_STORAGE"
+            | "LOOP_DETECTED"
+            | "BANDWIDTH_LIMIT_EXCEEDED"
+            | "NOT_EXTENDED"
+            | "NETWORK_AUTHENTICATION_REQUIRED";
+        };
+      };
+    };
+  };
+  updateLeague: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        clubId: number;
+        leagueId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LeagueUpdateRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["LeagueStatusUpdateResponse"];
+        };
+      };
+    };
+  };
+  updateClubMemberRole: {
+    parameters: {
+      query: {
+        clubMemberId: number;
+      };
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ClubMemberRoleUpdateRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ClubMemberResponse"];
+        };
+      };
+    };
+  };
+  expelClubMember: {
+    parameters: {
+      query: {
+        clubMemberId: number;
+      };
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ClubMemberExpelRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["clubMemberBanRecordResponse"];
+        };
+      };
+    };
+  };
+  banClubMember: {
+    parameters: {
+      query: {
+        clubMemberId: number;
+      };
+      header?: never;
+      path: {
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ClubMemberBanRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["clubMemberBanRecordResponse"];
+        };
+      };
+    };
+  };
+  getMemberInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MemberMyPageResponse"];
+        };
+      };
+    };
+  };
+  getMemberIsClubMember: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MemberIsClubMemberResponse"];
+        };
+      };
+    };
+  };
+  getLeagueByMonth: {
+    parameters: {
+      query: {
+        /** @description 조회할 날짜, 'yyyy-MM' 형식으로 입력 */
+        date: string;
+      };
+      header?: never;
+      path: {
+        /** @description 조회할 클럽의 ID */
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["LeagueReadResponse"][];
+        };
+      };
+    };
+  };
+  getLeagueByDate: {
+    parameters: {
+      query: {
+        /** @description 조회할 날짜, 'yyyy-MM-dd' 형식으로 입력 */
+        date: string;
+      };
+      header?: never;
+      path: {
+        /** @description 조회할 클럽의 ID */
+        clubId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["LeagueByDateResponse"][];
+        };
+      };
+    };
+  };
+  clubSearch: {
+    parameters: {
+      query?: {
+        page?: number;
+        size?: number;
+        sort?: string;
+        keyword?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["PageClubCardResponse"];
+        };
+      };
+    };
+  };
+  deleteMember: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MemberDeleteResponse"];
+        };
+      };
+    };
+  };
 }

--- a/schemas/schema.d.ts
+++ b/schemas/schema.d.ts
@@ -4,2007 +4,2017 @@
  */
 
 export interface paths {
-  "/v1/members/profileImage": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/profileImage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * 프로필 사진을 수정합니다
+         * @description 프로필 사진을 수정합니다
+         */
+        put: operations["updateProfileImage"];
+        /**
+         * 프로필 사진을 S3에 업로드 합니다
+         * @description 프로필 사진을 S3에 업로드합니다
+         */
+        post: operations["uploadProfileImage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    /**
-     * 프로필 사진을 수정합니다
-     * @description 프로필 사진을 수정합니다
-     */
-    put: operations["updateProfileImage"];
-    /**
-     * 프로필 사진을 S3에 업로드 합니다
-     * @description 프로필 사진을 S3에 업로드합니다
-     */
-    post: operations["uploadProfileImage"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/members/win": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/win": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 승리 기록 추가
+         * @description 회원의 리그 기록에 승리를 추가합니다
+         */
+        post: operations["addWin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 승리 기록 추가
-     * @description 회원의 리그 기록에 승리를 추가합니다
-     */
-    post: operations["addWin"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/members/refresh": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 액세스 토큰을 재발급합니다
+         * @description 리프레시 토큰을 이용해서 액세스 토큰을 재발급합니다
+         */
+        post: operations["refreshToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 액세스 토큰을 재발급합니다
-     * @description 리프레시 토큰을 이용해서 액세스 토큰을 재발급합니다
-     */
-    post: operations["refreshToken"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/members/lose": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/lose": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 패배 기록 추가
+         * @description 회원의 리그 기록에 패배를 추가합니다
+         */
+        post: operations["addLose"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 패배 기록 추가
-     * @description 회원의 리그 기록에 패배를 추가합니다
-     */
-    post: operations["addLose"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/members/logout": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 로그아웃을 합니다
+         * @description 쿠키에서 JWT 토큰을 제거해 로그아웃을 합니다
+         */
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 로그아웃을 합니다
-     * @description 쿠키에서 JWT 토큰을 제거해 로그아웃을 합니다
-     */
-    post: operations["logout"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 전체 동호회 조회
+         * @description 전체 동호회를 조회합니다.
+         */
+        get: operations["readAllClub"];
+        put?: never;
+        /**
+         * 동호회 추가
+         * @description 동호회를 추가합니다.
+         */
+        post: operations["createClub"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 전체 동호회 조회
-     * @description 전체 동호회를 조회합니다.
-     */
-    get: operations["readAllClub"];
-    put?: never;
-    /**
-     * 동호회 추가
-     * @description 동호회를 추가합니다.
-     */
-    post: operations["createClub"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/leagues": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 경기를 생성합니다.
+         * @description 경기 생성하고를 데이터베이스에 저장합니다.
+         */
+        post: operations["createLeague"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 해당 일자 기준으로 데이터를 조회합니다.
-     * @description 특정 클럽 ID에 대한 리그 데이터를 조회합니다. 검색 조건으로 날짜를 사용하며, 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
-     */
-    get: operations["leagueReadByCondition"];
-    put?: never;
-    /**
-     * 경기를 생성합니다.
-     * @description 경기 생성하고를 데이터베이스에 저장합니다.
-     */
-    post: operations["createLeague"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/leagues/{leagueId}/participation": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/{leagueId}/participation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 경기 참여 신청
+         * @description 동호회 회원이 경기 일정에 참여 신청을 합니다.
+         */
+        post: operations["participateInLeague"];
+        /**
+         * 경기 참여 신청 취소
+         * @description 경기 참여 신청을 취소합니다.
+         */
+        delete: operations["cancelLeagueParticipation"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 경기 참여 신청
-     * @description 동호회 회원이 경기 일정에 참여 신청을 합니다.
-     */
-    post: operations["participateInLeague"];
-    /**
-     * 경기 참여 신청 취소
-     * @description 경기 참여 신청을 취소합니다.
-     */
-    delete: operations["cancelLeagueParticipation"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/leagues/{leagueId}/matches": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/{leagueId}/matches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 대진표 조회
+         * @description 대진표를 조회합니다.
+         */
+        get: operations["getMatches"];
+        put?: never;
+        /**
+         * 대진표 생성
+         * @description 대진표를 생성합니다.
+         */
+        post: operations["makeMatches"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 대진표 조회
-     * @description 대진표를 조회합니다.
-     */
-    get: operations["getMatches"];
-    put?: never;
-    /**
-     * 대진표 생성
-     * @description 대진표를 생성합니다.
-     */
-    post: operations["makeMatches"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/leagues/{leagueId}/matches/{matchId}/set/{setIndex}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/{leagueId}/matches/{matchId}/set/{setIndex}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 세트별 점수 저장 */
+        post: operations["updateSetsScore"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 세트별 점수 저장 */
-    post: operations["updateSetsScore"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/leagues/{leagueId}/matches/details": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/{leagueId}/matches/details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 대진표 대진별, 세트별, 점수 초기화 */
+        post: operations["makeMatchesDetails"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 대진표 대진별, 세트별, 점수 초기화 */
-    post: operations["makeMatchesDetails"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/clubMembers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/clubMembers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 동호회 회원 전체 조회
+         * @description 동호회에 가입한 회원들의 리스트를 조회합니다.
+         */
+        get: operations["getClubMembersInClub"];
+        put?: never;
+        /**
+         * 동호회 가입 신청
+         * @description 동호회에 가입을 신청합니다.
+         */
+        post: operations["joinClub"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 동호회 회원 전체 조회
-     * @description 동호회에 가입한 회원들의 리스트를 조회합니다.
-     */
-    get: operations["getClubMembersInClub"];
-    put?: never;
-    /**
-     * 동호회 가입 신청
-     * @description 동호회에 가입을 신청합니다.
-     */
-    post: operations["joinClub"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/images": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 클럽 이미지 업로드
+         * @description 이미지를 S3에 업로드하는 API 입니다.
+         */
+        post: operations["saveImage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 클럽 이미지 업로드
-     * @description 이미지를 S3에 업로드하는 API 입니다.
-     */
-    post: operations["saveImage"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 동호회 조회
+         * @description 동호회를 조회합니다.
+         */
+        get: operations["readClub"];
+        put?: never;
+        post?: never;
+        /**
+         * 동호회 삭제
+         * @description 동호회를 삭제합니다.
+         */
+        delete: operations["deleteClub"];
+        options?: never;
+        head?: never;
+        /**
+         * 동호회 수정
+         * @description 동호회를 수정합니다.
+         */
+        patch: operations["updateClub"];
+        trace?: never;
     };
-    /**
-     * 동호회 조회
-     * @description 동호회를 조회합니다.
-     */
-    get: operations["readClub"];
-    put?: never;
-    post?: never;
-    /**
-     * 동호회 삭제
-     * @description 동호회를 삭제합니다.
-     */
-    delete: operations["deleteClub"];
-    options?: never;
-    head?: never;
-    /**
-     * 동호회 수정
-     * @description 동호회를 수정합니다.
-     */
-    patch: operations["updateClub"];
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/leagues/{leagueId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/{leagueId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 특정 경기를 조회합니다.
+         * @description 특정 경기를 경기 아이디를 통해 데이터베이스에서 조회합니다.
+         */
+        get: operations["leagueRead"];
+        put?: never;
+        post?: never;
+        /**
+         * 특정 경기를 삭제합니다.
+         * @description 특정 경기를 데이터베이스 테이블에서 제거합니다.
+         */
+        delete: operations["deleteLeague"];
+        options?: never;
+        head?: never;
+        /**
+         * 경기의 세부 정보를 변경합니다.
+         * @description 경기 제목, 경기 상태 등을 변경할 수 있습니다.
+         */
+        patch: operations["updateLeague"];
+        trace?: never;
     };
-    /**
-     * 특정 경기를 조회합니다.
-     * @description 특정 경기를 경기 아이디를 통해 데이터베이스에서 조회합니다.
-     */
-    get: operations["leagueRead"];
-    put?: never;
-    post?: never;
-    /**
-     * 특정 경기를 삭제합니다.
-     * @description 특정 경기를 데이터베이스 테이블에서 제거합니다.
-     */
-    delete: operations["deleteLeague"];
-    options?: never;
-    head?: never;
-    /**
-     * 경기의 세부 정보를 변경합니다.
-     * @description 경기 제목, 경기 상태 등을 변경할 수 있습니다.
-     */
-    patch: operations["updateLeague"];
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/clubMembers/role": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/clubMembers/role": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 동호회원 역할 변경
+         * @description 동호회원의 역할을 변경합니다.
+         */
+        patch: operations["updateClubMemberRole"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * 동호회원 역할 변경
-     * @description 동호회원의 역할을 변경합니다.
-     */
-    patch: operations["updateClubMemberRole"];
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/clubMembers/expel": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/clubMembers/expel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 동호회원 강제 탈퇴시키기
+         * @description 동호회원을 강제 탈퇴시킵니다.
+         */
+        patch: operations["expelClubMember"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * 동호회원 강제 탈퇴시키기
-     * @description 동호회원을 강제 탈퇴시킵니다.
-     */
-    patch: operations["expelClubMember"];
-    trace?: never;
-  };
-  "/v1/clubs/{clubId}/clubMembers/ban": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/clubMembers/ban": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 동호회원 정지
+         * @description 동호회원의 활동을 정지시킵니다.
+         */
+        patch: operations["banClubMember"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * 동호회원 정지
-     * @description 동호회원의 활동을 정지시킵니다.
-     */
-    patch: operations["banClubMember"];
-    trace?: never;
-  };
-  "/v1/members/myPage": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/myPage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 회원 정보를 조회합니다
+         * @description 회원의 마이페이지 접근 시 정보 조회 (동호회 정보 포함)
+         */
+        get: operations["getMemberInfo"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 회원 정보를 조회합니다
-     * @description 회원의 마이페이지 접근 시 정보 조회 (동호회 정보 포함)
-     */
-    get: operations["getMemberInfo"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/members/is-club-member": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/members/is-club-member": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 회원이 동호회에 가입되어있는지 확인합니다
+         * @description 회원이 동호회에 가입되어있는지 확인합니다
+         */
+        get: operations["getMemberIsClubMember"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 회원이 동호회에 가입되어있는지 확인합니다
-     * @description 회원이 동호회에 가입되어있는지 확인합니다
-     */
-    get: operations["getMemberIsClubMember"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/clubs/search": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/month": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 월별로 경기 일정을 조회합니다.
+         * @description 월별로 경기 일정을 리스트로 조회할 수 있습니다. 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
+         */
+        get: operations["getLeagueByMonth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 검색 조건에 맞는 동호회 조회
-     * @description 검색 조건에 맞는 동호회를 조회합니다.
-     */
-    get: operations["clubSearch"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/members": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/clubs/{clubId}/leagues/date": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 일자별로 경기 일정을 조회합니다.
+         * @description 일별로 경기 일정을 리스트로 조회할 수 있습니다. 검색 조건으로 날짜를 사용하며, 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.
+         */
+        get: operations["getLeagueByDate"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /**
-     * 회원 탈퇴를 합니다
-     * @description 멤버 필드의 isDeleted 를 true 로 변경합니다
-     */
-    delete: operations["deleteMember"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/v1/clubs/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 검색 조건에 맞는 동호회 조회
+         * @description 검색 조건에 맞는 동호회를 조회합니다.
+         */
+        get: operations["clubSearch"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 회원 탈퇴를 합니다
+         * @description 멤버 필드의 isDeleted 를 true 로 변경합니다
+         */
+        delete: operations["deleteMember"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    /** @description 회원 요청 DTO */
-    MemberResponse: {
-      /**
-       * Format: int64
-       * @description 회원 id
-       * @example 1
-       */
-      member_id?: number;
-      /**
-       * @description 회원 역할
-       * @example AUTHORIZATION_USER
-       */
-      authorization?: string;
-      /**
-       * @description 회원 이름
-       * @example 이선우
-       */
-      name?: string;
-      /**
-       * @description oAuth 로그인 이메일
-       * @example qosle@naver.com
-       */
-      email?: string;
-      /**
-       * @description oAuth 제공 ID
-       * @example 1070449979547641023123
-       */
-      provider_id?: string;
-      /**
-       * @description oAuth 제공 이미지
-       * @example 1070449979547641023123
-       */
-      profile_image?: string;
+    schemas: {
+        /** @description 회원 요청 DTO */
+        MemberResponse: {
+            /**
+             * Format: int64
+             * @description 회원 id
+             * @example 1
+             */
+            member_id?: number;
+            /**
+             * @description 회원 역할
+             * @example AUTHORIZATION_USER
+             */
+            authorization?: string;
+            /**
+             * @description 회원 이름
+             * @example 이선우
+             */
+            name?: string;
+            /**
+             * @description oAuth 로그인 이메일
+             * @example qosle@naver.com
+             */
+            email?: string;
+            /**
+             * @description oAuth 제공 ID
+             * @example 1070449979547641023123
+             */
+            provider_id?: string;
+            /**
+             * @description oAuth 제공 이미지
+             * @example 1070449979547641023123
+             */
+            profile_image?: string;
+        };
+        ImageUploadRequest: {
+            /** Format: binary */
+            multipartFile?: string;
+        };
+        ClubCreateRequest: {
+            club_name?: string;
+            club_description: string;
+            club_image?: string;
+        };
+        ClubCreateResponse: {
+            /** Format: int64 */
+            club_id?: number;
+            club_name?: string;
+            club_description?: string;
+            club_image?: string;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            modified_at?: string;
+        };
+        LeagueCreateRequest: {
+            /**
+             * @description 경기 이름
+             * @example 배드민턴 경기
+             */
+            league_name?: string;
+            /**
+             * @description 경기 설명
+             * @example 이 경기는 지역 예선 경기입니다.
+             */
+            description?: string;
+            /**
+             * @description 경기 장소
+             * @example 성동구 서울숲 체육센터
+             */
+            league_location?: string;
+            /**
+             * @description 최소 티어
+             * @example GOLD
+             * @enum {string}
+             */
+            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+            /**
+             * @description 경기 방식
+             * @example SINGLES
+             * @enum {string}
+             */
+            match_type?: "SINGLES" | "DOUBLES";
+            /**
+             * Format: date-time
+             * @description 경기 시작 날짜
+             */
+            league_at?: string;
+            /**
+             * Format: date-time
+             * @description 모집 마감 날짜
+             */
+            closed_at?: string;
+            /**
+             * Format: int32
+             * @description 참가 인원
+             * @example 16
+             */
+            player_count?: number;
+            /**
+             * @description 매칭 조건
+             * @example TIER
+             * @enum {string}
+             */
+            match_generation_type?: "RANDOM" | "TIER";
+        };
+        LeagueCreateResponse: {
+            /**
+             * @description 경기 이름
+             * @example 배드민턴 경기
+             */
+            league_name?: string;
+            /**
+             * @description 경기 설명
+             * @example 이 경기는 지역 예선 경기입니다.
+             */
+            description?: string;
+            /**
+             * @description 최소 티어
+             * @example GOLD
+             * @enum {string}
+             */
+            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+            /**
+             * @description 현재 경기 상태
+             * @example OPEN
+             * @enum {string}
+             */
+            status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+            /**
+             * @description 경기 방식
+             * @example SINGLE
+             * @enum {string}
+             */
+            match_type?: "SINGLES" | "DOUBLES";
+            /**
+             * Format: date-time
+             * @description 경기 시작 날짜
+             */
+            league_at?: string;
+            /**
+             * Format: date-time
+             * @description 모집 마감 날짜
+             */
+            closed_at?: string;
+            /**
+             * Format: int32
+             * @description 참가 인원
+             * @example 16
+             */
+            player_count?: number;
+            /**
+             * Format: date-time
+             * @description 생성 일자
+             */
+            created_at?: string;
+            /**
+             * Format: date-time
+             * @description 수정 일자
+             */
+            modified_at?: string;
+            /**
+             * @description 매칭 조건
+             * @example TIER
+             * @enum {string}
+             */
+            match_generation_type?: "RANDOM" | "TIER";
+        };
+        LeagueParticipantResponse: {
+            /** Format: int64 */
+            league_id?: number;
+            /** Format: int64 */
+            club_member_id?: number;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            modified_at?: string;
+        };
+        DoublesMatchResponse: {
+            team1?: components["schemas"]["TeamResponse"];
+            team2?: components["schemas"]["TeamResponse"];
+        };
+        MatchResponse: {
+            /** Format: int64 */
+            match_id?: number;
+            /** Format: int64 */
+            league_id?: number;
+            /** @enum {string} */
+            match_type?: "SINGLES" | "DOUBLES";
+            singles_match?: components["schemas"]["SinglesMatchResponse"];
+            doubles_match?: components["schemas"]["DoublesMatchResponse"];
+        };
+        SinglesMatchResponse: {
+            participant1_name?: string;
+            participant1_image?: string;
+            participant2_name?: string;
+            participant2_image?: string;
+        };
+        TeamResponse: {
+            participant1_name?: string;
+            participant1_image?: string;
+            participant2_name?: string;
+            participant2_image?: string;
+        };
+        SetScoreUpdateRequest: {
+            /** Format: int32 */
+            score1?: number;
+            /** Format: int32 */
+            score2?: number;
+        };
+        SetScoreUpdateResponse: {
+            /** Format: int64 */
+            match_id?: number;
+            /** Format: int32 */
+            set_index?: number;
+            /** Format: int32 */
+            score1?: number;
+            /** Format: int32 */
+            score2?: number;
+            /** @enum {string} */
+            match_type?: "SINGLES" | "DOUBLES";
+        };
+        DoublesSetResponse: {
+            /** Format: int32 */
+            set_index?: number;
+            /** Format: int32 */
+            score1?: number;
+            /** Format: int32 */
+            score2?: number;
+        };
+        MatchDetailsResponse: {
+            /** Format: int64 */
+            match_id?: number;
+            /** Format: int64 */
+            league_id?: number;
+            /** @enum {string} */
+            match_type?: "SINGLES" | "DOUBLES";
+            singles_match?: components["schemas"]["SinglesMatchResponse"];
+            doubles_match?: components["schemas"]["DoublesMatchResponse"];
+            singles_sets?: components["schemas"]["SinglesSetResponse"][];
+            doubles_sets?: components["schemas"]["DoublesSetResponse"][];
+        };
+        SinglesSetResponse: {
+            /** Format: int32 */
+            set_index?: number;
+            /** Format: int32 */
+            score1?: number;
+            /** Format: int32 */
+            score2?: number;
+        };
+        ClubMemberJoinResponse: {
+            /** Format: int64 */
+            club_member_id?: number;
+            role?: string;
+        };
+        ClubUpdateRequest: {
+            club_name: string;
+            club_description: string;
+            club_image?: string;
+        };
+        ClubUpdateResponse: {
+            /** Format: int64 */
+            club_id?: number;
+            club_name?: string;
+            club_description?: string;
+            club_image?: string;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            modified_at?: string;
+        };
+        LeagueUpdateRequest: {
+            /**
+             * @description 경기 이름
+             * @example 배드민턴 경기
+             */
+            league_name?: string;
+            /**
+             * @description 경기 설명
+             * @example 이 경기는 지역 예선 경기입니다.
+             */
+            description?: string;
+            /**
+             * @description 경기 장소
+             * @example 성동구 서울숲 체육센터
+             */
+            league_location?: string;
+            /**
+             * @description 최소 티어
+             * @example GOLD
+             * @enum {string}
+             */
+            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+            /**
+             * @description 경기 방식
+             * @example SINGLES
+             * @enum {string}
+             */
+            match_type?: "SINGLES" | "DOUBLES";
+            /**
+             * Format: date-time
+             * @description 경기 시작 날짜
+             */
+            league_at?: string;
+            /**
+             * Format: date-time
+             * @description 모집 마감 날짜
+             */
+            closed_at?: string;
+            /**
+             * Format: int32
+             * @description 참가 인원
+             * @example 16
+             */
+            player_count?: number;
+            /**
+             * @description 매칭 조건
+             * @example TIER
+             * @enum {string}
+             */
+            match_generation_type?: "RANDOM" | "TIER";
+        };
+        LeagueStatusUpdateResponse: {
+            /**
+             * Format: int64
+             * @description 특정 경기 아이디
+             */
+            league_id?: number;
+            /**
+             * @description 경기 이름
+             * @example 배드민턴 경기
+             */
+            league_name?: string;
+            /**
+             * @description 경기 설명
+             * @example 이 경기는 지역 예선 경기입니다.
+             */
+            description?: string;
+            /**
+             * @description 최소 티어
+             * @example GOLD
+             * @enum {string}
+             */
+            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+            /**
+             * @description 현재 경기 상태
+             * @example OPEN
+             * @enum {string}
+             */
+            league_status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+            /**
+             * @description 경기 방식
+             * @example SINGLE
+             * @enum {string}
+             */
+            match_type?: "SINGLES" | "DOUBLES";
+            /**
+             * Format: date-time
+             * @description 경기 시작 날짜
+             */
+            league_at?: string;
+            /**
+             * Format: date-time
+             * @description 모집 마감 날짜
+             */
+            closed_at?: string;
+            /**
+             * Format: int32
+             * @description 참가 인원
+             * @example 16
+             */
+            player_count?: number;
+            /**
+             * Format: date-time
+             * @description 수정 일자
+             */
+            modified_at?: string;
+            /**
+             * @description 매칭 조건
+             * @example TIER
+             * @enum {string}
+             */
+            match_generation_type?: "RANDOM" | "TIER";
+        };
+        ClubMemberRoleUpdateRequest: {
+            /** @enum {string} */
+            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+        };
+        ClubMemberResponse: {
+            /** Format: int64 */
+            club_member_id?: number;
+            image?: string;
+            name?: string;
+            /** @enum {string} */
+            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+            /** @enum {string} */
+            tier?: "GOLD" | "SILVER" | "BRONZE";
+            league_record_info_response?: components["schemas"]["LeagueRecordInfoResponse"];
+        };
+        LeagueRecordInfoResponse: {
+            /** Format: int32 */
+            win_count?: number;
+            /** Format: int32 */
+            lose_count?: number;
+            /** Format: int32 */
+            draw_count?: number;
+            /** Format: int32 */
+            match_count?: number;
+        };
+        ClubMemberExpelRequest: {
+            expel_reason?: string;
+        };
+        clubMemberBanRecordResponse: {
+            /** @enum {string} */
+            banned_type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
+            banned_reason?: string;
+            /** Format: int64 */
+            club_member_id?: number;
+            is_active?: boolean;
+            /** Format: date-time */
+            end_date?: string;
+        };
+        ClubMemberBanRequest: {
+            /** @enum {string} */
+            type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
+            banned_reason?: string;
+        };
+        /** @description ClubMember information */
+        ClubMemberMyPageResponse: {
+            /**
+             * Format: int64
+             * @description Club ID
+             * @example 1
+             */
+            club_id?: number;
+            /**
+             * Format: int64
+             * @description Club member ID
+             * @example 1
+             */
+            club_member_id?: number;
+            /**
+             * @description Club name
+             * @example 배드민턴 동호회
+             */
+            club_name?: string;
+            /**
+             * @description Member role
+             * @example ROLE_USER
+             * @enum {string}
+             */
+            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+            /**
+             * @description ClubMember Tier
+             * @example GOLD
+             * @enum {string}
+             */
+            tier?: "GOLD" | "SILVER" | "BRONZE";
+        };
+        /** @description Unified member response */
+        MemberMyPageResponse: {
+            /**
+             * Format: int64
+             * @description Member ID
+             * @example 1
+             */
+            member_id?: number;
+            /**
+             * @description Member name
+             * @example 김철수
+             */
+            name?: string;
+            /**
+             * @description Email
+             * @example example@email.com
+             */
+            email?: string;
+            /**
+             * @description Profile image URL
+             * @example https://example.com/profile.jpg
+             */
+            profile_image?: string;
+            club_member_my_page_response?: components["schemas"]["ClubMemberMyPageResponse"];
+            league_record_info?: components["schemas"]["LeagueRecordInfoResponse"];
+        };
+        MemberIsClubMemberResponse: {
+            is_club_member?: boolean;
+            /** @enum {string} */
+            role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
+            /** Format: int64 */
+            club_id?: number;
+        };
+        ClubCardResponse: {
+            /** Format: int64 */
+            club_id?: number;
+            club_name?: string;
+            club_description?: string;
+            club_image?: string;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            modified_at?: string;
+            club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
+        };
+        ClubMemberCountByTier: {
+            /** Format: int64 */
+            gold_club_member_count?: number;
+            /** Format: int64 */
+            silver_club_member_count?: number;
+            /** Format: int64 */
+            bronze_club_member_count?: number;
+        };
+        PageClubCardResponse: {
+            /** Format: int32 */
+            total_pages?: number;
+            /** Format: int64 */
+            total_elements?: number;
+            first?: boolean;
+            last?: boolean;
+            /** Format: int32 */
+            size?: number;
+            content?: components["schemas"]["ClubCardResponse"][];
+            /** Format: int32 */
+            number?: number;
+            sort?: components["schemas"]["SortObject"][];
+            /** Format: int32 */
+            number_of_elements?: number;
+            pageable?: components["schemas"]["PageableObject"];
+            empty?: boolean;
+        };
+        PageableObject: {
+            /** Format: int64 */
+            offset?: number;
+            sort?: components["schemas"]["SortObject"][];
+            paged?: boolean;
+            /** Format: int32 */
+            page_number?: number;
+            /** Format: int32 */
+            page_size?: number;
+            unpaged?: boolean;
+        };
+        SortObject: {
+            direction?: string;
+            null_handling?: string;
+            ascending?: boolean;
+            property?: string;
+            ignore_case?: boolean;
+        };
+        ClubDetailsResponse: {
+            /** Format: int64 */
+            club_id?: number;
+            club_name?: string;
+            club_description?: string;
+            club_image?: string;
+            club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
+            /** Format: int32 */
+            club_member_count?: number;
+            /** Format: date-time */
+            created_at?: string;
+            is_club_member?: boolean;
+        };
+        LeagueAndParticipantResponse: {
+            /**
+             * Format: int64
+             * @description 경기 아이디
+             */
+            league_id?: number;
+            /**
+             * @description 경기 이름
+             * @example 배드민턴 경기
+             */
+            league_name?: string;
+            /**
+             * @description 경기 설명
+             * @example 이 경기는 지역 예선 경기입니다.
+             */
+            description?: string;
+            /**
+             * @description 최소 티어
+             * @example GOLD
+             * @enum {string}
+             */
+            tier_limit?: "GOLD" | "SILVER" | "BRONZE";
+            /**
+             * @description 현재 경기 상태
+             * @example OPEN
+             * @enum {string}
+             */
+            status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+            /**
+             * @description 경기 방식
+             * @example SINGLE
+             * @enum {string}
+             */
+            match_type?: "SINGLES" | "DOUBLES";
+            /**
+             * Format: date-time
+             * @description 경기 시작 날짜
+             */
+            league_at?: string;
+            /**
+             * Format: date-time
+             * @description 모집 마감 날짜
+             */
+            closed_at?: string;
+            /**
+             * Format: int32
+             * @description 참가 제한 인원
+             * @example 16
+             */
+            player_limit_count?: number;
+            /**
+             * Format: date-time
+             * @description 생성 일자
+             */
+            created_at?: string;
+            /**
+             * Format: date-time
+             * @description 수정 일자
+             */
+            modified_at?: string;
+            /**
+             * @description 매칭 조건
+             * @example RANDOM
+             * @enum {string}
+             */
+            match_generation_type?: "RANDOM" | "TIER";
+            /**
+             * Format: int32
+             * @description 현재 참여 인원
+             * @example 0
+             */
+            player_count?: number;
+        };
+        LeagueReadResponse: {
+            /**
+             * Format: int64
+             * @description 경기 아이디
+             */
+            league_id?: number;
+            /**
+             * @description 경기 이름
+             * @example 배드민턴 경기
+             */
+            league_name?: string;
+            /**
+             * @description 현재 경기 상태
+             * @example OPEN
+             * @enum {string}
+             */
+            status?: "RECRUITING" | "COMPLETED" | "CANCELED";
+            /**
+             * Format: date-time
+             * @description 경기 시작 날짜
+             */
+            league_at?: string;
+            /**
+             * Format: int32
+             * @description 참가 인원
+             * @example 16
+             */
+            player_count?: number;
+        };
+        LeagueByDateResponse: {
+            /** Format: int64 */
+            league_id?: number;
+            /** Format: date-time */
+            league_at?: string;
+            league_name?: string;
+            /** @enum {string} */
+            match_type?: "SINGLES" | "DOUBLES";
+            /** @enum {string} */
+            required_tier?: "GOLD" | "SILVER" | "BRONZE";
+            /** Format: date-time */
+            closed_at?: string;
+            /** Format: int32 */
+            player_limit_count?: number;
+            /** Format: int32 */
+            recruited_member_count?: number;
+        };
+        /** @description 회원 삭제 responseDto */
+        MemberDeleteResponse: {
+            /**
+             * Format: int64
+             * @description 멤버 id
+             * @example 1
+             */
+            member_id?: number;
+            /**
+             * @description 삭제 여부
+             * @example true
+             */
+            is_deleted?: boolean;
+        };
+        ClubDeleteResponse: {
+            /** Format: int64 */
+            club_id?: number;
+            is_club_deleted?: boolean;
+        };
+        LeagueParticipationCancelResponse: {
+            /** Format: int64 */
+            league_id?: number;
+            /** Format: int64 */
+            club_member_id?: number;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            deleted_at?: string;
+        };
     };
-    ImageUploadRequest: {
-      /** Format: binary */
-      multipartFile?: string;
-    };
-    ClubCreateRequest: {
-      club_name?: string;
-      club_description: string;
-      club_image?: string;
-    };
-    ClubCreateResponse: {
-      /** Format: int64 */
-      club_id?: number;
-      club_name?: string;
-      club_description?: string;
-      club_image?: string;
-      /** Format: date-time */
-      created_at?: string;
-      /** Format: date-time */
-      modified_at?: string;
-    };
-    LeagueCreateRequest: {
-      /**
-       * @description 경기 이름
-       * @example 배드민턴 경기
-       */
-      league_name?: string;
-      /**
-       * @description 경기 설명
-       * @example 이 경기는 지역 예선 경기입니다.
-       */
-      description?: string;
-      /**
-       * @description 경기 장소
-       * @example 성동구 서울숲 체육센터
-       */
-      league_location?: string;
-      /**
-       * @description 최소 티어
-       * @example GOLD
-       * @enum {string}
-       */
-      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-      /**
-       * @description 경기 방식
-       * @example SINGLES
-       * @enum {string}
-       */
-      match_type?: "SINGLES" | "DOUBLES";
-      /**
-       * Format: date-time
-       * @description 경기 시작 날짜
-       */
-      league_at?: string;
-      /**
-       * Format: date-time
-       * @description 모집 마감 날짜
-       */
-      closed_at?: string;
-      /**
-       * Format: int32
-       * @description 참가 인원
-       * @example 16
-       */
-      player_count?: number;
-      /**
-       * @description 매칭 조건
-       * @example TIER
-       * @enum {string}
-       */
-      match_generation_type?: "RANDOM" | "TIER";
-    };
-    LeagueCreateResponse: {
-      /**
-       * @description 경기 이름
-       * @example 배드민턴 경기
-       */
-      league_name?: string;
-      /**
-       * @description 경기 설명
-       * @example 이 경기는 지역 예선 경기입니다.
-       */
-      description?: string;
-      /**
-       * @description 최소 티어
-       * @example GOLD
-       * @enum {string}
-       */
-      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-      /**
-       * @description 현재 경기 상태
-       * @example OPEN
-       * @enum {string}
-       */
-      status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-      /**
-       * @description 경기 방식
-       * @example SINGLE
-       * @enum {string}
-       */
-      match_type?: "SINGLES" | "DOUBLES";
-      /**
-       * Format: date-time
-       * @description 경기 시작 날짜
-       */
-      league_at?: string;
-      /**
-       * Format: date-time
-       * @description 모집 마감 날짜
-       */
-      closed_at?: string;
-      /**
-       * Format: int32
-       * @description 참가 인원
-       * @example 16
-       */
-      player_count?: number;
-      /**
-       * Format: date-time
-       * @description 생성 일자
-       */
-      created_at?: string;
-      /**
-       * Format: date-time
-       * @description 수정 일자
-       */
-      modified_at?: string;
-      /**
-       * @description 매칭 조건
-       * @example TIER
-       * @enum {string}
-       */
-      match_generation_type?: "RANDOM" | "TIER";
-    };
-    LeagueParticipantResponse: {
-      /** Format: int64 */
-      league_id?: number;
-      /** Format: int64 */
-      club_member_id?: number;
-      /** Format: date-time */
-      created_at?: string;
-      /** Format: date-time */
-      modified_at?: string;
-    };
-    DoublesMatchResponse: {
-      team1?: components["schemas"]["TeamResponse"];
-      team2?: components["schemas"]["TeamResponse"];
-    };
-    MatchResponse: {
-      /** Format: int64 */
-      match_id?: number;
-      /** Format: int64 */
-      league_id?: number;
-      /** @enum {string} */
-      match_type?: "SINGLES" | "DOUBLES";
-      singles_match?: components["schemas"]["SinglesMatchResponse"];
-      doubles_match?: components["schemas"]["DoublesMatchResponse"];
-    };
-    SinglesMatchResponse: {
-      participant1_name?: string;
-      participant1_image?: string;
-      participant2_name?: string;
-      participant2_image?: string;
-    };
-    TeamResponse: {
-      participant1_name?: string;
-      participant1_image?: string;
-      participant2_name?: string;
-      participant2_image?: string;
-    };
-    SetScoreUpdateRequest: {
-      /** Format: int32 */
-      score1?: number;
-      /** Format: int32 */
-      score2?: number;
-    };
-    SetScoreUpdateResponse: {
-      /** Format: int64 */
-      match_id?: number;
-      /** Format: int32 */
-      set_index?: number;
-      /** Format: int32 */
-      score1?: number;
-      /** Format: int32 */
-      score2?: number;
-      /** @enum {string} */
-      match_type?: "SINGLES" | "DOUBLES";
-    };
-    DoublesSetResponse: {
-      /** Format: int32 */
-      set_index?: number;
-      /** Format: int32 */
-      score1?: number;
-      /** Format: int32 */
-      score2?: number;
-    };
-    MatchDetailsResponse: {
-      /** Format: int64 */
-      match_id?: number;
-      /** Format: int64 */
-      league_id?: number;
-      /** @enum {string} */
-      match_type?: "SINGLES" | "DOUBLES";
-      singles_match?: components["schemas"]["SinglesMatchResponse"];
-      doubles_match?: components["schemas"]["DoublesMatchResponse"];
-      singles_sets?: components["schemas"]["SinglesSetResponse"][];
-      doubles_sets?: components["schemas"]["DoublesSetResponse"][];
-    };
-    SinglesSetResponse: {
-      /** Format: int32 */
-      set_index?: number;
-      /** Format: int32 */
-      score1?: number;
-      /** Format: int32 */
-      score2?: number;
-    };
-    ClubMemberJoinResponse: {
-      /** Format: int64 */
-      club_member_id?: number;
-      role?: string;
-    };
-    ClubUpdateRequest: {
-      club_name: string;
-      club_description: string;
-      club_image?: string;
-    };
-    ClubUpdateResponse: {
-      /** Format: int64 */
-      club_id?: number;
-      club_name?: string;
-      club_description?: string;
-      club_image?: string;
-      /** Format: date-time */
-      created_at?: string;
-      /** Format: date-time */
-      modified_at?: string;
-    };
-    LeagueUpdateRequest: {
-      /**
-       * @description 경기 이름
-       * @example 배드민턴 경기
-       */
-      league_name?: string;
-      /**
-       * @description 경기 설명
-       * @example 이 경기는 지역 예선 경기입니다.
-       */
-      description?: string;
-      /**
-       * @description 경기 장소
-       * @example 성동구 서울숲 체육센터
-       */
-      league_location?: string;
-      /**
-       * @description 최소 티어
-       * @example GOLD
-       * @enum {string}
-       */
-      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-      /**
-       * @description 경기 방식
-       * @example SINGLES
-       * @enum {string}
-       */
-      match_type?: "SINGLES" | "DOUBLES";
-      /**
-       * Format: date-time
-       * @description 경기 시작 날짜
-       */
-      league_at?: string;
-      /**
-       * Format: date-time
-       * @description 모집 마감 날짜
-       */
-      closed_at?: string;
-      /**
-       * Format: int32
-       * @description 참가 인원
-       * @example 16
-       */
-      player_count?: number;
-      /**
-       * @description 매칭 조건
-       * @example TIER
-       * @enum {string}
-       */
-      match_generation_type?: "RANDOM" | "TIER";
-    };
-    LeagueStatusUpdateResponse: {
-      /**
-       * Format: int64
-       * @description 특정 경기 아이디
-       */
-      league_id?: number;
-      /**
-       * @description 경기 이름
-       * @example 배드민턴 경기
-       */
-      league_name?: string;
-      /**
-       * @description 경기 설명
-       * @example 이 경기는 지역 예선 경기입니다.
-       */
-      description?: string;
-      /**
-       * @description 최소 티어
-       * @example GOLD
-       * @enum {string}
-       */
-      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-      /**
-       * @description 현재 경기 상태
-       * @example OPEN
-       * @enum {string}
-       */
-      league_status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-      /**
-       * @description 경기 방식
-       * @example SINGLE
-       * @enum {string}
-       */
-      match_type?: "SINGLES" | "DOUBLES";
-      /**
-       * Format: date-time
-       * @description 경기 시작 날짜
-       */
-      league_at?: string;
-      /**
-       * Format: date-time
-       * @description 모집 마감 날짜
-       */
-      closed_at?: string;
-      /**
-       * Format: int32
-       * @description 참가 인원
-       * @example 16
-       */
-      player_count?: number;
-      /**
-       * Format: date-time
-       * @description 수정 일자
-       */
-      modified_at?: string;
-      /**
-       * @description 매칭 조건
-       * @example TIER
-       * @enum {string}
-       */
-      match_generation_type?: "RANDOM" | "TIER";
-    };
-    ClubMemberRoleUpdateRequest: {
-      /** @enum {string} */
-      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-    };
-    ClubMemberResponse: {
-      /** Format: int64 */
-      club_member_id?: number;
-      image?: string;
-      name?: string;
-      /** @enum {string} */
-      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-      /** @enum {string} */
-      tier?: "GOLD" | "SILVER" | "BRONZE";
-      league_record_info_response?: components["schemas"]["LeagueRecordInfoResponse"];
-    };
-    LeagueRecordInfoResponse: {
-      /** Format: int32 */
-      win_count?: number;
-      /** Format: int32 */
-      lose_count?: number;
-      /** Format: int32 */
-      draw_count?: number;
-      /** Format: int32 */
-      match_count?: number;
-    };
-    ClubMemberExpelRequest: {
-      expel_reason?: string;
-    };
-    clubMemberBanRecordResponse: {
-      /** @enum {string} */
-      banned_type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
-      banned_reason?: string;
-      /** Format: int64 */
-      club_member_id?: number;
-      is_active?: boolean;
-      /** Format: date-time */
-      end_date?: string;
-    };
-    ClubMemberBanRequest: {
-      /** @enum {string} */
-      type?: "THREE_DAYS" | "SEVEN_DAYS" | "TWO_WEEKS" | "PERMANENT";
-      banned_reason?: string;
-    };
-    /** @description ClubMember information */
-    ClubMemberMyPageResponse: {
-      /**
-       * Format: int64
-       * @description Club ID
-       * @example 1
-       */
-      club_id?: number;
-      /**
-       * Format: int64
-       * @description Club member ID
-       * @example 1
-       */
-      club_member_id?: number;
-      /**
-       * @description Club name
-       * @example 배드민턴 동호회
-       */
-      club_name?: string;
-      /**
-       * @description Member role
-       * @example ROLE_USER
-       * @enum {string}
-       */
-      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-      /**
-       * @description ClubMember Tier
-       * @example GOLD
-       * @enum {string}
-       */
-      tier?: "GOLD" | "SILVER" | "BRONZE";
-    };
-    /** @description Unified member response */
-    MemberMyPageResponse: {
-      /**
-       * Format: int64
-       * @description Member ID
-       * @example 1
-       */
-      member_id?: number;
-      /**
-       * @description Member name
-       * @example 김철수
-       */
-      name?: string;
-      /**
-       * @description Email
-       * @example example@email.com
-       */
-      email?: string;
-      /**
-       * @description Profile image URL
-       * @example https://example.com/profile.jpg
-       */
-      profile_image?: string;
-      club_member_my_page_response?: components["schemas"]["ClubMemberMyPageResponse"];
-      league_record_info?: components["schemas"]["LeagueRecordInfoResponse"];
-    };
-    MemberIsClubMemberResponse: {
-      is_club_member?: boolean;
-      /** @enum {string} */
-      role?: "ROLE_OWNER" | "ROLE_MANAGER" | "ROLE_USER";
-      /** Format: int64 */
-      club_id?: number;
-    };
-    ClubCardResponse: {
-      /** Format: int64 */
-      club_id?: number;
-      club_name?: string;
-      club_description?: string;
-      club_image?: string;
-      /** Format: date-time */
-      created_at?: string;
-      /** Format: date-time */
-      modified_at?: string;
-      club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
-    };
-    ClubMemberCountByTier: {
-      /** Format: int64 */
-      gold_club_member_count?: number;
-      /** Format: int64 */
-      silver_club_member_count?: number;
-      /** Format: int64 */
-      bronze_club_member_count?: number;
-    };
-    PageClubCardResponse: {
-      /** Format: int32 */
-      total_pages?: number;
-      /** Format: int64 */
-      total_elements?: number;
-      first?: boolean;
-      last?: boolean;
-      /** Format: int32 */
-      size?: number;
-      content?: components["schemas"]["ClubCardResponse"][];
-      /** Format: int32 */
-      number?: number;
-      sort?: components["schemas"]["SortObject"][];
-      /** Format: int32 */
-      number_of_elements?: number;
-      pageable?: components["schemas"]["PageableObject"];
-      empty?: boolean;
-    };
-    PageableObject: {
-      /** Format: int64 */
-      offset?: number;
-      sort?: components["schemas"]["SortObject"][];
-      paged?: boolean;
-      /** Format: int32 */
-      page_number?: number;
-      /** Format: int32 */
-      page_size?: number;
-      unpaged?: boolean;
-    };
-    SortObject: {
-      direction?: string;
-      null_handling?: string;
-      ascending?: boolean;
-      property?: string;
-      ignore_case?: boolean;
-    };
-    ClubDetailsResponse: {
-      /** Format: int64 */
-      club_id?: number;
-      club_name?: string;
-      club_description?: string;
-      club_image?: string;
-      club_member_count_by_tier?: components["schemas"]["ClubMemberCountByTier"];
-      /** Format: int32 */
-      club_member_count?: number;
-      /** Format: date-time */
-      created_at?: string;
-      is_club_member?: boolean;
-    };
-    LeagueReadResponse: {
-      /**
-       * Format: int64
-       * @description 경기 아이디
-       */
-      league_id?: number;
-      /**
-       * @description 경기 이름
-       * @example 배드민턴 경기
-       */
-      league_name?: string;
-      /**
-       * @description 현재 경기 상태
-       * @example OPEN
-       * @enum {string}
-       */
-      status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-      /**
-       * Format: date-time
-       * @description 경기 시작 날짜
-       */
-      league_at?: string;
-      /**
-       * Format: int32
-       * @description 참가 인원
-       * @example 16
-       */
-      player_count?: number;
-    };
-    LeagueAndParticipantResponse: {
-      /**
-       * Format: int64
-       * @description 경기 아이디
-       */
-      league_id?: number;
-      /**
-       * @description 경기 이름
-       * @example 배드민턴 경기
-       */
-      league_name?: string;
-      /**
-       * @description 경기 설명
-       * @example 이 경기는 지역 예선 경기입니다.
-       */
-      description?: string;
-      /**
-       * @description 최소 티어
-       * @example GOLD
-       * @enum {string}
-       */
-      tier_limit?: "GOLD" | "SILVER" | "BRONZE";
-      /**
-       * @description 현재 경기 상태
-       * @example OPEN
-       * @enum {string}
-       */
-      status?: "RECRUITING" | "COMPLETED" | "CANCELED";
-      /**
-       * @description 경기 방식
-       * @example SINGLE
-       * @enum {string}
-       */
-      match_type?: "SINGLES" | "DOUBLES";
-      /**
-       * Format: date-time
-       * @description 경기 시작 날짜
-       */
-      league_at?: string;
-      /**
-       * Format: date-time
-       * @description 모집 마감 날짜
-       */
-      closed_at?: string;
-      /**
-       * Format: int32
-       * @description 참가 제한 인원
-       * @example 16
-       */
-      player_limit_count?: number;
-      /**
-       * Format: date-time
-       * @description 생성 일자
-       */
-      created_at?: string;
-      /**
-       * Format: date-time
-       * @description 수정 일자
-       */
-      modified_at?: string;
-      /**
-       * @description 매칭 조건
-       * @example RANDOM
-       * @enum {string}
-       */
-      match_generation_type?: "RANDOM" | "TIER";
-      /**
-       * Format: int32
-       * @description 현재 참여 인원
-       * @example 0
-       */
-      player_count?: number;
-    };
-    /** @description 회원 삭제 responseDto */
-    MemberDeleteResponse: {
-      /**
-       * Format: int64
-       * @description 멤버 id
-       * @example 1
-       */
-      member_id?: number;
-      /**
-       * @description 삭제 여부
-       * @example true
-       */
-      is_deleted?: boolean;
-    };
-    ClubDeleteResponse: {
-      /** Format: int64 */
-      club_id?: number;
-      is_club_deleted?: boolean;
-    };
-    LeagueParticipationCancelResponse: {
-      /** Format: int64 */
-      league_id?: number;
-      /** Format: int64 */
-      club_member_id?: number;
-      /** Format: date-time */
-      created_at?: string;
-      /** Format: date-time */
-      deleted_at?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  updateProfileImage: {
-    parameters: {
-      query: {
-        imageUrl: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MemberResponse"];
-        };
-      };
-    };
-  };
-  uploadProfileImage: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["ImageUploadRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": string;
-        };
-      };
-    };
-  };
-  addWin: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": string;
-        };
-      };
-    };
-  };
-  refreshToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": Record<string, never>;
-        };
-      };
-    };
-  };
-  addLose: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": string;
-        };
-      };
-    };
-  };
-  logout: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": string;
-        };
-      };
-    };
-  };
-  readAllClub: {
-    parameters: {
-      query?: {
-        page?: number;
-        size?: number;
-        sort?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["PageClubCardResponse"];
-        };
-      };
-    };
-  };
-  createClub: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ClubCreateRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["ClubCreateResponse"];
-        };
-      };
-    };
-  };
-  leagueReadByCondition: {
-    parameters: {
-      query: {
-        /** @description 조회할 날짜, 'yyyy-MM' 형식으로 입력 */
-        date: string;
-      };
-      header?: never;
-      path: {
-        /** @description 조회할 클럽의 ID */
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["LeagueReadResponse"][];
-        };
-      };
-    };
-  };
-  createLeague: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LeagueCreateRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["LeagueCreateResponse"];
-        };
-      };
-    };
-  };
-  participateInLeague: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["LeagueParticipantResponse"];
-        };
-      };
-    };
-  };
-  cancelLeagueParticipation: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["LeagueParticipationCancelResponse"];
-        };
-      };
-    };
-  };
-  getMatches: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MatchResponse"][];
-        };
-      };
-    };
-  };
-  makeMatches: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MatchResponse"][];
-        };
-      };
-    };
-  };
-  updateSetsScore: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-        matchId: number;
-        setIndex: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SetScoreUpdateRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["SetScoreUpdateResponse"];
-        };
-      };
-    };
-  };
-  makeMatchesDetails: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MatchDetailsResponse"][];
-        };
-      };
-    };
-  };
-  getClubMembersInClub: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": {
-            [key: string]: components["schemas"]["ClubMemberResponse"][];
-          };
-        };
-      };
-    };
-  };
-  joinClub: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /**
-         * @description 동호회 ID
-         * @example 1
-         */
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["ClubMemberJoinResponse"];
-        };
-      };
-    };
-  };
-  saveImage: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["ImageUploadRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": string;
-        };
-      };
-    };
-  };
-  readClub: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["ClubDetailsResponse"];
-        };
-      };
-    };
-  };
-  deleteClub: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["ClubDeleteResponse"];
-        };
-      };
-    };
-  };
-  updateClub: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ClubUpdateRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["ClubUpdateResponse"];
-        };
-      };
-    };
-  };
-  leagueRead: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["LeagueAndParticipantResponse"];
-        };
-      };
-    };
-  };
-  deleteLeague: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*":
-            | "CONTINUE"
-            | "SWITCHING_PROTOCOLS"
-            | "PROCESSING"
-            | "EARLY_HINTS"
-            | "CHECKPOINT"
-            | "OK"
-            | "CREATED"
-            | "ACCEPTED"
-            | "NON_AUTHORITATIVE_INFORMATION"
-            | "NO_CONTENT"
-            | "RESET_CONTENT"
-            | "PARTIAL_CONTENT"
-            | "MULTI_STATUS"
-            | "ALREADY_REPORTED"
-            | "IM_USED"
-            | "MULTIPLE_CHOICES"
-            | "MOVED_PERMANENTLY"
-            | "FOUND"
-            | "MOVED_TEMPORARILY"
-            | "SEE_OTHER"
-            | "NOT_MODIFIED"
-            | "USE_PROXY"
-            | "TEMPORARY_REDIRECT"
-            | "PERMANENT_REDIRECT"
-            | "BAD_REQUEST"
-            | "UNAUTHORIZED"
-            | "PAYMENT_REQUIRED"
-            | "FORBIDDEN"
-            | "NOT_FOUND"
-            | "METHOD_NOT_ALLOWED"
-            | "NOT_ACCEPTABLE"
-            | "PROXY_AUTHENTICATION_REQUIRED"
-            | "REQUEST_TIMEOUT"
-            | "CONFLICT"
-            | "GONE"
-            | "LENGTH_REQUIRED"
-            | "PRECONDITION_FAILED"
-            | "PAYLOAD_TOO_LARGE"
-            | "REQUEST_ENTITY_TOO_LARGE"
-            | "URI_TOO_LONG"
-            | "REQUEST_URI_TOO_LONG"
-            | "UNSUPPORTED_MEDIA_TYPE"
-            | "REQUESTED_RANGE_NOT_SATISFIABLE"
-            | "EXPECTATION_FAILED"
-            | "I_AM_A_TEAPOT"
-            | "INSUFFICIENT_SPACE_ON_RESOURCE"
-            | "METHOD_FAILURE"
-            | "DESTINATION_LOCKED"
-            | "UNPROCESSABLE_ENTITY"
-            | "LOCKED"
-            | "FAILED_DEPENDENCY"
-            | "TOO_EARLY"
-            | "UPGRADE_REQUIRED"
-            | "PRECONDITION_REQUIRED"
-            | "TOO_MANY_REQUESTS"
-            | "REQUEST_HEADER_FIELDS_TOO_LARGE"
-            | "UNAVAILABLE_FOR_LEGAL_REASONS"
-            | "INTERNAL_SERVER_ERROR"
-            | "NOT_IMPLEMENTED"
-            | "BAD_GATEWAY"
-            | "SERVICE_UNAVAILABLE"
-            | "GATEWAY_TIMEOUT"
-            | "HTTP_VERSION_NOT_SUPPORTED"
-            | "VARIANT_ALSO_NEGOTIATES"
-            | "INSUFFICIENT_STORAGE"
-            | "LOOP_DETECTED"
-            | "BANDWIDTH_LIMIT_EXCEEDED"
-            | "NOT_EXTENDED"
-            | "NETWORK_AUTHENTICATION_REQUIRED";
-        };
-      };
-    };
-  };
-  updateLeague: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clubId: number;
-        leagueId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LeagueUpdateRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["LeagueStatusUpdateResponse"];
-        };
-      };
-    };
-  };
-  updateClubMemberRole: {
-    parameters: {
-      query: {
-        clubMemberId: number;
-      };
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ClubMemberRoleUpdateRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["ClubMemberResponse"];
-        };
-      };
-    };
-  };
-  expelClubMember: {
-    parameters: {
-      query: {
-        clubMemberId: number;
-      };
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ClubMemberExpelRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["clubMemberBanRecordResponse"];
-        };
-      };
-    };
-  };
-  banClubMember: {
-    parameters: {
-      query: {
-        clubMemberId: number;
-      };
-      header?: never;
-      path: {
-        clubId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ClubMemberBanRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["clubMemberBanRecordResponse"];
-        };
-      };
-    };
-  };
-  getMemberInfo: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MemberMyPageResponse"];
-        };
-      };
-    };
-  };
-  getMemberIsClubMember: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MemberIsClubMemberResponse"];
-        };
-      };
-    };
-  };
-  clubSearch: {
-    parameters: {
-      query?: {
-        page?: number;
-        size?: number;
-        sort?: string;
-        keyword?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["PageClubCardResponse"];
-        };
-      };
-    };
-  };
-  deleteMember: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MemberDeleteResponse"];
-        };
-      };
-    };
-  };
+    updateProfileImage: {
+        parameters: {
+            query: {
+                imageUrl: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MemberResponse"];
+                };
+            };
+        };
+    };
+    uploadProfileImage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["ImageUploadRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+        };
+    };
+    addWin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+        };
+    };
+    refreshToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": Record<string, never>;
+                };
+            };
+        };
+    };
+    addLose: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+        };
+    };
+    readAllClub: {
+        parameters: {
+            query?: {
+                page?: number;
+                size?: number;
+                sort?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PageClubCardResponse"];
+                };
+            };
+        };
+    };
+    createClub: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClubCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ClubCreateResponse"];
+                };
+            };
+        };
+    };
+    createLeague: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LeagueCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueCreateResponse"];
+                };
+            };
+        };
+    };
+    participateInLeague: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueParticipantResponse"];
+                };
+            };
+        };
+    };
+    cancelLeagueParticipation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueParticipationCancelResponse"];
+                };
+            };
+        };
+    };
+    getMatches: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MatchResponse"][];
+                };
+            };
+        };
+    };
+    makeMatches: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MatchResponse"][];
+                };
+            };
+        };
+    };
+    updateSetsScore: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+                matchId: number;
+                setIndex: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetScoreUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SetScoreUpdateResponse"];
+                };
+            };
+        };
+    };
+    makeMatchesDetails: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MatchDetailsResponse"][];
+                };
+            };
+        };
+    };
+    getClubMembersInClub: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": {
+                        [key: string]: components["schemas"]["ClubMemberResponse"][];
+                    };
+                };
+            };
+        };
+    };
+    joinClub: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description 동호회 ID
+                 * @example 1
+                 */
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ClubMemberJoinResponse"];
+                };
+            };
+        };
+    };
+    saveImage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["ImageUploadRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+        };
+    };
+    readClub: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ClubDetailsResponse"];
+                };
+            };
+        };
+    };
+    deleteClub: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ClubDeleteResponse"];
+                };
+            };
+        };
+    };
+    updateClub: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClubUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ClubUpdateResponse"];
+                };
+            };
+        };
+    };
+    leagueRead: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueAndParticipantResponse"];
+                };
+            };
+        };
+    };
+    deleteLeague: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": "CONTINUE" | "SWITCHING_PROTOCOLS" | "PROCESSING" | "EARLY_HINTS" | "CHECKPOINT" | "OK" | "CREATED" | "ACCEPTED" | "NON_AUTHORITATIVE_INFORMATION" | "NO_CONTENT" | "RESET_CONTENT" | "PARTIAL_CONTENT" | "MULTI_STATUS" | "ALREADY_REPORTED" | "IM_USED" | "MULTIPLE_CHOICES" | "MOVED_PERMANENTLY" | "FOUND" | "MOVED_TEMPORARILY" | "SEE_OTHER" | "NOT_MODIFIED" | "USE_PROXY" | "TEMPORARY_REDIRECT" | "PERMANENT_REDIRECT" | "BAD_REQUEST" | "UNAUTHORIZED" | "PAYMENT_REQUIRED" | "FORBIDDEN" | "NOT_FOUND" | "METHOD_NOT_ALLOWED" | "NOT_ACCEPTABLE" | "PROXY_AUTHENTICATION_REQUIRED" | "REQUEST_TIMEOUT" | "CONFLICT" | "GONE" | "LENGTH_REQUIRED" | "PRECONDITION_FAILED" | "PAYLOAD_TOO_LARGE" | "REQUEST_ENTITY_TOO_LARGE" | "URI_TOO_LONG" | "REQUEST_URI_TOO_LONG" | "UNSUPPORTED_MEDIA_TYPE" | "REQUESTED_RANGE_NOT_SATISFIABLE" | "EXPECTATION_FAILED" | "I_AM_A_TEAPOT" | "INSUFFICIENT_SPACE_ON_RESOURCE" | "METHOD_FAILURE" | "DESTINATION_LOCKED" | "UNPROCESSABLE_ENTITY" | "LOCKED" | "FAILED_DEPENDENCY" | "TOO_EARLY" | "UPGRADE_REQUIRED" | "PRECONDITION_REQUIRED" | "TOO_MANY_REQUESTS" | "REQUEST_HEADER_FIELDS_TOO_LARGE" | "UNAVAILABLE_FOR_LEGAL_REASONS" | "INTERNAL_SERVER_ERROR" | "NOT_IMPLEMENTED" | "BAD_GATEWAY" | "SERVICE_UNAVAILABLE" | "GATEWAY_TIMEOUT" | "HTTP_VERSION_NOT_SUPPORTED" | "VARIANT_ALSO_NEGOTIATES" | "INSUFFICIENT_STORAGE" | "LOOP_DETECTED" | "BANDWIDTH_LIMIT_EXCEEDED" | "NOT_EXTENDED" | "NETWORK_AUTHENTICATION_REQUIRED";
+                };
+            };
+        };
+    };
+    updateLeague: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clubId: number;
+                leagueId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LeagueUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueStatusUpdateResponse"];
+                };
+            };
+        };
+    };
+    updateClubMemberRole: {
+        parameters: {
+            query: {
+                clubMemberId: number;
+            };
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClubMemberRoleUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ClubMemberResponse"];
+                };
+            };
+        };
+    };
+    expelClubMember: {
+        parameters: {
+            query: {
+                clubMemberId: number;
+            };
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClubMemberExpelRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["clubMemberBanRecordResponse"];
+                };
+            };
+        };
+    };
+    banClubMember: {
+        parameters: {
+            query: {
+                clubMemberId: number;
+            };
+            header?: never;
+            path: {
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClubMemberBanRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["clubMemberBanRecordResponse"];
+                };
+            };
+        };
+    };
+    getMemberInfo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MemberMyPageResponse"];
+                };
+            };
+        };
+    };
+    getMemberIsClubMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MemberIsClubMemberResponse"];
+                };
+            };
+        };
+    };
+    getLeagueByMonth: {
+        parameters: {
+            query: {
+                /** @description 조회할 날짜, 'yyyy-MM' 형식으로 입력 */
+                date: string;
+            };
+            header?: never;
+            path: {
+                /** @description 조회할 클럽의 ID */
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueReadResponse"][];
+                };
+            };
+        };
+    };
+    getLeagueByDate: {
+        parameters: {
+            query: {
+                /** @description 조회할 날짜, 'yyyy-MM-dd' 형식으로 입력 */
+                date: string;
+            };
+            header?: never;
+            path: {
+                /** @description 조회할 클럽의 ID */
+                clubId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LeagueByDateResponse"][];
+                };
+            };
+        };
+    };
+    clubSearch: {
+        parameters: {
+            query?: {
+                page?: number;
+                size?: number;
+                sort?: string;
+                keyword?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PageClubCardResponse"];
+                };
+            };
+        };
+    };
+    deleteMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["MemberDeleteResponse"];
+                };
+            };
+        };
+    };
 }

--- a/utils/getLeagueType.ts
+++ b/utils/getLeagueType.ts
@@ -1,0 +1,10 @@
+export const getLeagueType = (type: string) => {
+  switch (type) {
+    case "SINGLES":
+      return "단식";
+    case "DOUBLES":
+      return "복식";
+    default:
+      return "";
+  }
+};


### PR DESCRIPTION
- Close #134

## What is this PR? 🔍

- 기능 : 일별 경기 일정 조회 구현
- issue : #134

## Changes 📝
- 일별 일정 조회 연동
- 스케줄 요소 정렬
- 스케줄 없을 때 처리
- 일 선택 시 월도 같이 fetch하는 에러 해결
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
