### PR TITLE
feat: match detail 페이지 생성

### DIFF
--- a/app/club/[clubId]/league/[leagueId]/match/[matchId]/page.tsx
+++ b/app/club/[clubId]/league/[leagueId]/match/[matchId]/page.tsx
@@ -1,7 +1,8 @@
+import MatchDetail from "@/components/pages/club/MatchDetail";
 import React from "react";
 
 function page() {
-  return <div>page</div>;
+  return <MatchDetail />;
 }
 
 export default page;

--- a/components/club/TournamentBracket/MatchNode.tsx
+++ b/components/club/TournamentBracket/MatchNode.tsx
@@ -18,7 +18,7 @@ function MatchNode({ data }: MatchNodeProps) {
   const team2Score = data.team2[0]?.participant_win_set_count || 0;
 
   return (
-    <div>
+    <div className="cursor-pointer">
       <div className="flex bg-gray-700">
         <div>
           {data.team1.map((player) => {

--- a/components/club/TournamentBracket/index.tsx
+++ b/components/club/TournamentBracket/index.tsx
@@ -13,6 +13,7 @@ import React, { useMemo } from "react";
 import "@xyflow/react/dist/style.css";
 import type { components } from "@/schemas/schema";
 import type { GetMatchesData, MatchParticipant } from "@/types/matchTypes";
+import { useParams, useRouter } from "next/navigation";
 
 // SinglesMatchResponse는 participant1, participant2만 있음
 type SinglesMatch = components["schemas"]["SinglesMatchResponse"] & {
@@ -284,6 +285,10 @@ export default function TournamentBracket(props: TournamentBracketProps) {
 
   const nodeTypes = useMemo(() => ({ match: MatchNode }), []);
 
+  const router = useRouter();
+
+  const { clubId, leagueId } = useParams();
+
   return (
     <div className="w-full h-[65vh] bg-gray-900 rounded-md">
       <ReactFlow
@@ -294,6 +299,13 @@ export default function TournamentBracket(props: TournamentBracketProps) {
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}
+        onNodeClick={(event, node) => {
+          // 클릭한 노드의 id 값을 가져옵니다
+          const { id } = node;
+
+          // 해당 id를 이용해 URL로 이동합니다
+          router.push(`/club/${clubId}/league/${leagueId}/match/${id}`);
+        }}
       >
         <Controls />
         <MiniMap />

--- a/components/pages/club/MatchDetail.tsx
+++ b/components/pages/club/MatchDetail.tsx
@@ -1,0 +1,81 @@
+import SImage from "@/components/ui/Image";
+import { Badge } from "@/components/ui/badge";
+import { getTierWithEmoji } from "@/utils/getTier";
+import Image from "next/image";
+import React from "react";
+
+const ScoreCard = () => {
+  return (
+    <>
+      <div className="flex items-center justify-evenly flex-col w-full gap-6 min-h-[500px]">
+        <div className="grid grid-cols-3 gap-6 items-center mb-6 w-2/3">
+          {/* Player 1 */}
+          <div className="flex flex-col items-center justify-center space-y-2">
+            <div className="w-24 h-24 rounded-full overflow-hidden">
+              <img
+                src="/images/dummy-image.jpg"
+                alt="Player 1"
+                className="object-cover"
+              />
+            </div>
+            <span className="font-semibold text-lg text-gray-800">
+              {getTierWithEmoji("GOLD")}LeeKaChang
+            </span>
+          </div>
+
+          {/* VS */}
+          <div className="text-3xl font-bold text-gray-800 flex items-center justify-center">
+            VS
+          </div>
+
+          {/* Player 2 */}
+          <div className="flex flex-col items-center justify-center space-y-2">
+            <div className="w-24 h-24 rounded-full overflow-hidden">
+              <img
+                src="/images/dummy-image.jpg"
+                alt="Player 2"
+                className="object-cover"
+              />
+            </div>
+            <span className="font-semibold text-lg text-gray-800">
+              {getTierWithEmoji("SILVER")}LeeKaChang
+            </span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-6 text-center w-2/3">
+          <div className="flex flex-col items-center justify-center space-y-2 min-h-12">
+            <span className="text-xl font-bold text-gray-700">21</span>
+            <span className="text-xl font-bold text-gray-700">2</span>
+            <span className="text-xl font-bold text-gray-700">25</span>
+            <span className="text-xl font-bold text-gray-700">2</span>
+          </div>
+
+          <div className="flex flex-col items-center justify-center space-y-2 min-h-12">
+            <Badge className="bg-yellow-300 hover:bg-yellow-300 text-base font-semibold text-center rounded-sm w-16 flex justify-center items-center">
+              1세트
+            </Badge>
+            <Badge className="bg-yellow-400 hover:bg-yellow-400 text-base font-semibold text-center rounded-sm w-16 flex justify-center items-center">
+              2세트
+            </Badge>
+            <Badge className="bg-yellow-500 hover:bg-yellow-500 text-base font-semibold text-center rounded-sm w-16 flex justify-center items-center">
+              3세트
+            </Badge>
+            <Badge className="bg-yellow-600 hover:bg-yellow-600 text-base font-semibold text-center rounded-sm w-16 flex justify-center items-center">
+              결과
+            </Badge>
+          </div>
+
+          <div className="flex flex-col items-center justify-center space-y-2 min-h-12">
+            <span className="text-xl font-bold text-gray-700">21</span>
+            <span className="text-xl font-bold text-gray-700">2</span>
+            <span className="text-xl font-bold text-gray-700">25</span>
+            <span className="text-xl font-bold text-gray-700">2</span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ScoreCard;


### PR DESCRIPTION
- Close #216

## What is this PR? 🔍

- 기능 : match detail 페이지를 생성했습니다. 
- issue : #216

## Changes 📝
- 토너먼트 노드 클릭하면 페이지 이동하는 것 까지 구현했습니다. 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/c517fe58-fe73-48f9-b6cc-5376f87d6eec)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
