### PR TITLE
fix: 동호회 생성 안되는 오류 해결

### DIFF
--- a/components/pages/club/ClubCreate.tsx
+++ b/components/pages/club/ClubCreate.tsx
@@ -16,7 +16,9 @@ function ClubCreate() {
   const router = useRouter();
   const [imgUrl, setImgUrl] = useState<string>("/images/dummy-image.jpg");
   const { mutate: createClubImg } = usePostClubsImg();
-  const { mutate: createClub } = usePostClubs();
+  const { mutate: createClub } = usePostClubs((clubId) => {
+    router.push(`/club/${clubId}`);
+  });
 
   const {
     register,
@@ -36,8 +38,8 @@ function ClubCreate() {
 
     createClubImg(formData, {
       onSuccess: (data) => {
-        setImgUrl(data);
-        setValue("club_image", data);
+        setImgUrl(data.data || "/images/dummy-image.jpg");
+        setValue("club_image", data.data);
         clearErrors("club_image"); // 업로드 성공 시 에러 메시지 제거
       },
       onError: () => {
@@ -65,12 +67,7 @@ function ClubCreate() {
       club_image: imgUrl,
     };
 
-    // createClub(newClubData, {
-    //   onSuccess: (data) => {
-    //     const clubId = data.club_id;
-    //     router.push(`/club/${clubId}`);
-    //   },
-    // });
+    createClub(newClubData);
   };
 
   return (

--- a/components/pages/club/ClubManage.tsx
+++ b/components/pages/club/ClubManage.tsx
@@ -51,8 +51,8 @@ function ClubManage() {
 
     patchClubImg(formData, {
       onSuccess: (data) => {
-        setImgUrl(data);
-        setValue("club_image", data);
+        setImgUrl(data.data);
+        setValue("club_image", data.data);
         clearErrors("club_image");
       },
       onError: () => {

--- a/lib/api/functions/clubFn.ts
+++ b/lib/api/functions/clubFn.ts
@@ -6,6 +6,7 @@ import type {
   GetRecentlyClubListResponse,
   PatchClubRequest,
   PatchClubResponse,
+  PostClubImageResponse,
   PostClubRequest,
   PostClubResponse,
 } from "@/types/clubTypes";
@@ -62,8 +63,10 @@ export const postClubs = async (
   return restClient.post<PostClubResponse>("/clubs", clubData);
 };
 
-export const postClubsImg = async (clubImg: FormData): Promise<string> => {
-  return restClient.postImage<string>("/clubs/images", clubImg);
+export const postClubsImg = async (
+  clubImg: FormData,
+): Promise<PostClubImageResponse> => {
+  return restClient.postImage<PostClubImageResponse>("/clubs/images", clubImg);
 };
 
 export const getClubsById = async (

--- a/lib/api/hooks/useMutationWithToast.ts
+++ b/lib/api/hooks/useMutationWithToast.ts
@@ -14,7 +14,7 @@ interface CommonResponse<T> {
 
 const useMutationWithToast = <TData, TRequestBody>(
   mutationFn: (requestBody: TRequestBody) => Promise<CommonResponse<TData>>,
-  onSuccessCallback?: () => void,
+  onSuccessCallback?: (data: TData) => void,
 ): {
   isSuccess: boolean;
   isPending: boolean;
@@ -31,8 +31,8 @@ const useMutationWithToast = <TData, TRequestBody>(
   >({
     mutationFn,
     onSuccess: (data) => {
-      if (data.result === "SUCCESS" && onSuccessCallback) {
-        onSuccessCallback();
+      if (data.result === "SUCCESS" && data.data) {
+        onSuccessCallback?.(data.data);
         setDataResult(true);
       }
       if (data.result === "FAIL") {

--- a/types/clubTypes.ts
+++ b/types/clubTypes.ts
@@ -27,6 +27,11 @@ export type PostClubRequest = components["schemas"]["ClubCreateRequest"];
 export type PostClubResponse =
   components["schemas"]["CommonResponseClubCreateResponse"];
 
+export type PostClubData = components["schemas"]["ClubCreateResponse"];
+
+export type PostClubImageResponse =
+  components["schemas"]["CommonResponseString"];
+
 export type PatchClubRequest = components["schemas"]["ClubUpdateRequest"];
 
 export type PatchClubResponse =


### PR DESCRIPTION
- Close #228

## What is this PR? 🔍

- 기능 :동호회 생성 안되는 오류 해결
- issue : #228

## Changes 📝
- useMutationWithToast 의 onSuccessCallback 함수에 매개변수 옵셔널하게 넣을 수 있도록 수정함
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
