### PR TITLE
fix: 프로필 사진 수정 안되는 오류 해결

### DIFF
--- a/components/pages/myPage/EditProfileDialog.tsx
+++ b/components/pages/myPage/EditProfileDialog.tsx
@@ -75,19 +75,26 @@ function EditProfileDialog({
   };
 
   const handleImageRemove = () => {
+    // 이미지 삭제 후 기본 이미지 설정
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
-    setProfileImage(DEFAULT_IMAGE!); // 이미지 삭제 후 기본 이미지 설정
+    setProfileImage(DEFAULT_IMAGE!); // 기본 이미지 설정
     setUploadedImageFile(null); // 업로드된 파일 정보 초기화
     form.setValue("profileImage", DEFAULT_IMAGE); // 폼 값도 기본 이미지로 설정
   };
 
   const onSubmit: SubmitHandler<ProfileFormInputs> = (data) => {
     const { name } = data;
-    // 이름만 수정하는 경우에는 기존 프로필 이미지 유지
-    const profileImageUrl =
-      uploadedImageFile || profileImage === DEFAULT_IMAGE
-        ? profileImage
-        : initialProfileImage;
+    let profileImageUrl: string;
+
+    // 이미지 삭제 후, 수정할 때 기본 이미지를 설정하는 부분
+    if (uploadedImageFile) {
+      profileImageUrl = profileImage; // 업로드된 이미지 사용
+    } else if (profileImage === DEFAULT_IMAGE) {
+      // biome-ignore lint/style/noNonNullAssertion: <explanation>
+      profileImageUrl = DEFAULT_IMAGE!; // 기본 이미지 사용
+    } else {
+      profileImageUrl = initialProfileImage; // 이름만 수정 시 기존 이미지 그대로 사용
+    }
 
     if (uploadedImageFile) {
       const formData = new FormData();
@@ -110,7 +117,7 @@ function EditProfileDialog({
     } else {
       putProfile({
         name,
-        profile_image_url: profileImageUrl, // 이름만 수정 시 기존 이미지 그대로 사용
+        profile_image_url: profileImageUrl, // 선택된 이미지로 업데이트
       });
     }
   };


### PR DESCRIPTION
- Close #246

## What is this PR? 🔍

- 기능 : 프로필 사진 수정 안되는 오류 해결
- issue : #246

## Changes 📝
- 프로필 사진은 옵셔널하게 제약조건 변경
- 이미지 삭제 후 기본이미지 설정 로직 변경
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
