### PR TITLE
fix: 경기 생성자만 수정, 삭제 가능하게 수정

### DIFF
--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -37,6 +37,7 @@ function LeagueDetail() {
     clubId as string,
     leagueId as string,
   );
+  const { data: loginedUser } = useGetMembersSession();
   const { data: leagueCheck } = useGetLeagueCheck(
     clubId as string,
     leagueId as string,
@@ -146,27 +147,29 @@ function LeagueDetail() {
             </Text>
           </div>
         </div>
-        <div className="flex justify-center gap-2">
-          <Link href={`/club/${clubId}/league/${leagueId}/update`}>
+        {loginedUser?.data?.member_token === league?.league_owner_token && (
+          <div className="flex justify-center gap-2">
+            <Link href={`/club/${clubId}/league/${leagueId}/update`}>
+              <Button
+                size="sm"
+                variant="outline"
+                className="flex items-center gap-1 border-primary"
+              >
+                <Pencil size={16} />
+                수정
+              </Button>
+            </Link>
             <Button
               size="sm"
-              variant="outline"
-              className="flex items-center gap-1 border-primary"
+              variant="destructive"
+              className="flex items-center gap-1"
+              onClick={() => deleteLeague()}
             >
-              <Pencil size={16} />
-              수정
+              <Trash2 size={16} />
+              삭제
             </Button>
-          </Link>
-          <Button
-            size="sm"
-            variant="destructive"
-            className="flex items-center gap-1"
-            onClick={() => deleteLeague()}
-          >
-            <Trash2 size={16} />
-            삭제
-          </Button>
-        </div>
+          </div>
+        )}
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">

--- a/schemas/schema.d.ts
+++ b/schemas/schema.d.ts
@@ -2628,6 +2628,11 @@ export interface components {
        */
       name?: string;
       /**
+       * @description 회원 토큰
+       * @example member_token_1
+       */
+      member_token?: string;
+      /**
        * @description oAuth 로그인 이메일
        * @example qosle@naver.com
        */
@@ -3648,6 +3653,8 @@ export interface components {
        * @description 경기 아이디
        */
       league_id: number;
+      /** @description 경기 오너 토큰 */
+      league_owner_token: string;
       /** @description 경기 이름 */
       league_name: string;
       /** @description 경기 설명 */


### PR DESCRIPTION
- Close #248

## What is this PR? 🔍

- 기능 : 경기 생성자만 수정, 삭제 가능하게 수정
- issue : #248

## Changes 📝
- 경기 생성자가 아닌 경우는 경기 수정, 삭제 하지 못하도록 막았습니다.
- session api와 league 상세 보기 api 의 member token을 이용했습니다. 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
