### PR TITLE
fix: 경기 참여 로직 수정

### DIFF
--- a/components/club/LeagueDetail/LeagueInfo.tsx
+++ b/components/club/LeagueDetail/LeagueInfo.tsx
@@ -1,0 +1,22 @@
+interface LeagueInfoProps {
+  icon: React.ElementType;
+  label: string; // 제목 또는 레이블
+  value: string | number | null | undefined; // 값 (텍스트 또는 숫자)
+}
+
+function LeagueInfo(props: LeagueInfoProps) {
+  const { icon: Icon, label, value } = props;
+  return (
+    <div>
+      <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
+        <Icon className="text-gray-500" size={24} />
+        <div>
+          <p className="text-xs text-gray-500">{label}</p>
+          <p className="text-sm font-semibold text-gray-800">{value}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LeagueInfo;

--- a/components/club/LeagueDetail/MatchButton.tsx
+++ b/components/club/LeagueDetail/MatchButton.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@/components/ui/Button";
+import type { GetLeagueDetailData } from "@/types/leagueTypes";
+import { BookUser } from "lucide-react";
+import Link from "next/link";
+
+interface MatchButtonProps {
+  clubId: string;
+  leagueId: string;
+  league: GetLeagueDetailData;
+  createMatch: () => void; // 대진표 생성 함수 타입 정의;
+}
+
+const MatchButton = ({
+  leagueId,
+  clubId,
+  league,
+  createMatch,
+}: MatchButtonProps) => {
+  const matchCreateCondition =
+    (league.league_status === "RECRUITING_COMPLETED" ||
+      league.league_status === "PLAYING") &&
+    !league?.is_match_created;
+
+  if (matchCreateCondition) {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="items-center justify-center gap-2 border-primary w-1/3 hover:bg-white hover:text-primary"
+        onClick={createMatch}
+      >
+        <BookUser size={20} />
+        대진표 생성
+      </Button>
+    );
+  }
+
+  if (league.is_match_created) {
+    return (
+      <Link
+        href={`/club/${clubId}/league/${leagueId}/match`}
+        className="flex justify-center items-center gap-4 w-1/3"
+      >
+        <Button
+          size="lg"
+          variant="outline"
+          className="items-center justify-center gap-2 border-primary w-full"
+        >
+          <BookUser size={20} />
+          대진표 보기
+        </Button>
+      </Link>
+    );
+  }
+
+  return null;
+};
+
+export default MatchButton;

--- a/components/club/LeagueDetail/ParticipateButton.tsx
+++ b/components/club/LeagueDetail/ParticipateButton.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@/components/ui/Button";
+import type { Tier } from "@/types/commonTypes";
+import type { GetLeagueDetailData } from "@/types/leagueTypes";
+import type { GetMemberSessionResponse } from "@/types/memberTypes";
+import { User } from "lucide-react";
+import { useRouter } from "next/navigation";
+import type React from "react";
+
+interface ParticipateButtonProps {
+  league: GetLeagueDetailData;
+  loginedUser: GetMemberSessionResponse;
+  handleParticipate: (status: boolean) => void;
+  isParticipating: boolean;
+}
+
+const canParticipate = (userTier: Tier, requiredTier: Tier): boolean => {
+  if (userTier === "GOLD") {
+    return true; // GOLD 티어는 모든 경기에 참가 가능
+  }
+
+  if (userTier === "SILVER") {
+    return requiredTier === "SILVER" || requiredTier === "BRONZE";
+    // SILVER 티어는 SILVER, BRONZE 경기에 참가 가능
+  }
+
+  if (userTier === "BRONZE") {
+    return requiredTier === "BRONZE";
+    // BRONZE 티어는 BRONZE 경기에만 참가 가능
+  }
+
+  // 위 조건에 해당하지 않는 경우 참가 불가
+  return false;
+};
+
+function ParticipateButton({
+  league,
+  loginedUser,
+  handleParticipate,
+  isParticipating,
+}: ParticipateButtonProps) {
+  const router = useRouter();
+
+  // 리그 생성자 여부 확인
+  const isLeagueOwner =
+    loginedUser?.data?.member_token === league.league_owner_token;
+
+  // 모집 상태 확인
+  const isRecruiting = league.league_status === "RECRUITING";
+
+  // 모집 인원 초과 여부 확인
+  const isFull = league.recruited_member_count === league.player_limit_count;
+
+  // 사용자 티어와 리그 티어 비교
+  const canUserParticipate =
+    loginedUser &&
+    canParticipate(loginedUser?.data?.member_tier, league.required_tier);
+
+  // 로그인 하지 않은 사용자 처리
+  if (loginedUser.result === "FAIL") {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="items-center justify-center gap-2 border-primary w-1/3 hover:bg-white hover:text-primary"
+        onClick={() => router.push("/login")}
+      >
+        <User size={20} />
+        경기 참가
+      </Button>
+    );
+  }
+
+  // 경기 생성자 처리
+  if (isLeagueOwner) {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="cursor-not-allowed items-center justify-center gap-2 border-primary w-1/3 border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
+      >
+        경기 생성자는 참가 취소를 할 수 없습니다
+      </Button>
+    );
+  }
+
+  // 참여 신청 한 사람 처리
+  if (isParticipating) {
+    return (
+      <Button
+        size="lg"
+        variant="destructive"
+        className="items-center justify-center gap-2 border-primary w-1/3"
+        onClick={() => handleParticipate(true)}
+      >
+        <User size={20} />
+        참가 취소
+      </Button>
+    );
+  }
+
+  // 모집중 아닐 때 처리
+  if (!isRecruiting) {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="cursor-not-allowed items-center justify-center gap-2 border-primary w-1/3 border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
+      >
+        모집중인 경기가 아닙니다
+      </Button>
+    );
+  }
+
+  // 지원할 수 있는 티어가 아닐 때 처리
+  if (!canUserParticipate) {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="cursor-not-allowed items-center justify-center gap-2 border-primary w-1/3 border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
+      >
+        지원할 수 있는 티어가 아닙니다
+      </Button>
+    );
+  }
+
+  // 모집 인원이 가득 찼을 때 처리
+  if (isFull) {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="cursor-not-allowed items-center justify-center gap-2 border-primary w-1/3 border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
+      >
+        모집 인원이 가득 찼습니다
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      size="lg"
+      variant="outline"
+      className="items-center justify-center gap-2 border-primary w-1/3 hover:bg-white hover:text-primary"
+      onClick={() => handleParticipate(false)}
+    >
+      <User size={20} />
+      경기 참가
+    </Button>
+  );
+}
+
+export default ParticipateButton;

--- a/components/club/LeagueDetail/ParticipateButton.tsx
+++ b/components/club/LeagueDetail/ParticipateButton.tsx
@@ -57,6 +57,10 @@ function ParticipateButton({
     loginedUser &&
     canParticipate(loginedUser?.data?.member_tier, league.required_tier);
 
+  if (league.league_status === "CANCELED") {
+    return null;
+  }
+
   // 로그인 하지 않은 사용자 처리
   if (loginedUser.result === "FAIL") {
     return (

--- a/components/club/LeagueDetail/ParticipateButton.tsx
+++ b/components/club/LeagueDetail/ParticipateButton.tsx
@@ -44,8 +44,10 @@ function ParticipateButton({
   const isLeagueOwner =
     loginedUser?.data?.member_token === league.league_owner_token;
 
-  // 모집 상태 확인
-  const isRecruiting = league.league_status === "RECRUITING";
+  // 모집 상태 확인 (RECRUITING 또는 RECRUITING_COMPLETED 상태 포함)
+  const isRecruitingOrCompleted =
+    league.league_status === "RECRUITING" ||
+    league.league_status === "RECRUITING_COMPLETED";
 
   // 모집 인원 초과 여부 확인
   const isFull = league.recruited_member_count === league.player_limit_count;
@@ -83,6 +85,19 @@ function ParticipateButton({
     );
   }
 
+  // 모집중 또는 모집 완료 상태가 아닌 경우 처리
+  if (!isRecruitingOrCompleted) {
+    return (
+      <Button
+        size="lg"
+        variant="outline"
+        className="cursor-not-allowed items-center justify-center gap-2 border-primary w-1/3 border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
+      >
+        모집중인 경기가 아닙니다
+      </Button>
+    );
+  }
+
   // 참여 신청 한 사람 처리
   if (isParticipating) {
     return (
@@ -94,19 +109,6 @@ function ParticipateButton({
       >
         <User size={20} />
         참가 취소
-      </Button>
-    );
-  }
-
-  // 모집중 아닐 때 처리
-  if (!isRecruiting) {
-    return (
-      <Button
-        size="lg"
-        variant="outline"
-        className="cursor-not-allowed items-center justify-center gap-2 border-primary w-1/3 border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
-      >
-        모집중인 경기가 아닙니다
       </Button>
     );
   }
@@ -137,6 +139,7 @@ function ParticipateButton({
     );
   }
 
+  // 참가 신청 가능 버튼
   return (
     <Button
       size="lg"

--- a/components/pages/LiveMatchList.tsx
+++ b/components/pages/LiveMatchList.tsx
@@ -16,7 +16,7 @@ import {
   useGetMainLeaguesMatch,
 } from "@/lib/api/hooks/mainLeagueHook";
 import { useGetMembersSession } from "@/lib/api/hooks/memberHook";
-import type { LeagueStatus, TierLimit } from "@/types/leagueTypes";
+import type { LeagueStatus, Tier } from "@/types/commonTypes";
 import type {
   GetMainLeagues,
   GetMainLeaguesMatchData,
@@ -61,7 +61,7 @@ const renderLeagueStatusButton = (
   }
 };
 
-const renderLeagueTierBadge = (tier: TierLimit) => {
+const renderLeagueTierBadge = (tier: Tier) => {
   if (tier === "GOLD") {
     return (
       <Badge

--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -28,7 +28,7 @@ import {
   MapPin,
   Pencil,
   Pyramid,
-  Trash2,
+  TicketX,
   User,
 } from "lucide-react";
 import Link from "next/link";
@@ -146,12 +146,12 @@ function LeagueDetail() {
               </Link>
               <Button
                 size="sm"
-                variant="destructive"
-                className="flex items-center gap-1"
+                variant="outline"
+                className="flex items-center gap-1 hover:bg-zinc-500 hover:text-white border-zinc-500 text-zinc-500"
                 onClick={() => deleteLeague()}
               >
-                <Trash2 size={16} />
-                삭제
+                <TicketX size={16} />
+                취소
               </Button>
             </div>
           )}

--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Spinner from "@/components/Spinner";
+import LeagueInfo from "@/components/club/LeagueDetail/LeagueInfo";
 import { Button } from "@/components/ui/Button";
 import { Text } from "@/components/ui/Text";
 import { useGetClubMembersCheck } from "@/lib/api/hooks/clubMemberHook";
@@ -268,82 +269,55 @@ function LeagueDetail() {
           )}
       </div>
       <div className="grid grid-cols-2 gap-4">
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <Calendar className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">경기 일자</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {league?.league_at &&
-                format(new Date(league.league_at), "yyyy-MM-dd HH시 mm분")}
-            </p>
-          </div>
-        </div>
+        <LeagueInfo
+          icon={Calendar}
+          label="경기 일자"
+          value={
+            league?.league_at &&
+            format(new Date(league.league_at), "yyyy-MM-dd HH시 mm분")
+          }
+        />
 
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <Flag className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">모집 상태</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {getRecruitmentStatusLabel(league?.league_status || "")}
-            </p>
-          </div>
-        </div>
+        <LeagueInfo
+          icon={Flag}
+          label="모집 상태"
+          value={getRecruitmentStatusLabel(league?.league_status || "")}
+        />
 
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <MapPin className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">경기 장소</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {league?.region}
-            </p>
-          </div>
-        </div>
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <User className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">모집 인원</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {league?.recruited_member_count} / {league?.player_limit_count} 명
-            </p>
-          </div>
-        </div>
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <Calendar className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">모집 마감 일자</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {league?.recruiting_closed_at &&
-                format(new Date(league.recruiting_closed_at), "yyyy-MM-dd")}
-            </p>
-          </div>
-        </div>
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <Award className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">지원 티어</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {getTierWithEmojiAndText(league?.required_tier || "")}
-            </p>
-          </div>
-        </div>
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <Pyramid className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">경기 유형</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {league?.match_type === "SINGLES" ? "단식" : "복식"}
-            </p>
-          </div>
-        </div>
-        <div className="p-4 bg-gray-100 rounded-lg flex items-center gap-3">
-          <GitCompare className="text-gray-500" size={24} />
-          <div>
-            <p className="text-xs text-gray-500">대진표 타입</p>
-            <p className="text-sm font-semibold text-gray-800">
-              {league?.match_generation_type === "FREE" ? "프리" : "토너먼트"}
-            </p>
-          </div>
-        </div>
+        <LeagueInfo icon={MapPin} label="경기 장소" value={league?.region} />
+
+        <LeagueInfo
+          icon={User}
+          label="모집 인원"
+          value={`${league?.recruited_member_count} / ${league?.player_limit_count} 명`}
+        />
+
+        <LeagueInfo
+          icon={Calendar}
+          label="모집 마감 일자"
+          value={
+            league?.recruiting_closed_at &&
+            format(new Date(league.recruiting_closed_at), "yyyy-MM-dd")
+          }
+        />
+
+        <LeagueInfo
+          icon={Award}
+          label="지원 가능 티어"
+          value={getTierWithEmojiAndText(league?.required_tier || "")}
+        />
+
+        <LeagueInfo
+          icon={Pyramid}
+          label="경기 유형"
+          value={league?.match_type === "SINGLES" ? "단식" : "복식"}
+        />
+
+        <LeagueInfo
+          icon={GitCompare}
+          label="대진표 타입"
+          value={league?.match_generation_type === "FREE" ? "프리" : "토너먼트"}
+        />
       </div>
 
       <div>

--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -357,24 +357,7 @@ function LeagueDetail() {
       </div>
       <div className="flex w-full justify-evenly items-center mt-8">
         {renderButtonByMatchCreatedStatus()}
-        {/* TODO(Yejin0O0): 지원 가능한 티어 경기에만 버튼 보이도록 수정 */}
-        {/* {league?.league_status === "RECRUITING" && (
-          <Button
-            size="lg"
-            variant={
-              leagueCheck?.data?.is_participated_in_league
-                ? "destructive"
-                : "default"
-            }
-            className="items-center justify-center gap-2 border-primary w-1/3"
-            onClick={() => handleParticipate()}
-          >
-            <User size={20} />
-            {leagueCheck?.data?.is_participated_in_league
-              ? "참가 취소"
-              : "참가하기"}
-          </Button>
-        )} */}
+
         {renderParticipateButton()}
       </div>
     </div>

--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -72,20 +72,21 @@ function LeagueDetail() {
   const { mutate: deleteParticipate } = useDeleteParticipantLeague(
     clubId as string,
     leagueId as string,
-    () => alert("경기 신청 취소가 완료되었습니다"),
+    () => alert("경기 참여 취소가 완료되었습니다"),
   );
   const { mutate: deleteLeague } = useDeleteLeague(
     clubId as string,
     leagueId as string,
+    () => alert("경기 취소가 완료되었습니다"),
   );
   const { mutate: createMatch } = usePostMatches(
     clubId as string,
     leagueId as string,
+    () => router.push(`/club/${clubId}/league/${leagueId}/match`),
   );
-  const { data: sessionData } = useGetMembersSession();
 
   const handleParticipate = (status: boolean) => {
-    if (sessionData?.result === "FAIL") {
+    if (loginedUser?.result === "FAIL") {
       alert("로그인이 필요한 기능입니다");
       return router.push("/login");
     }
@@ -103,9 +104,13 @@ function LeagueDetail() {
   };
 
   const makeMatch = () => {
-    createMatch(undefined, {
-      onSuccess: () => router.push(`/club/${clubId}/league/${leagueId}/match`),
-    });
+    createMatch();
+  };
+
+  const cancelLeague = () => {
+    if (confirm("정말로 경기를 취소하시겠습니까?")) {
+      deleteLeague();
+    }
   };
 
   if (isLoading) {
@@ -132,7 +137,8 @@ function LeagueDetail() {
           </div>
         </div>
         {!!loginedUser?.data &&
-          loginedUser.data.member_token === league?.league_owner_token && (
+          loginedUser.data.member_token === league?.league_owner_token &&
+          league?.league_status !== "CANCELED" && (
             <div className="flex justify-center gap-2">
               <Link href={`/club/${clubId}/league/${leagueId}/update`}>
                 <Button
@@ -148,7 +154,7 @@ function LeagueDetail() {
                 size="sm"
                 variant="outline"
                 className="flex items-center gap-1 hover:bg-zinc-500 hover:text-white border-zinc-500 text-zinc-500"
-                onClick={() => deleteLeague()}
+                onClick={cancelLeague}
               >
                 <TicketX size={16} />
                 취소

--- a/lib/api/functions/leagueFn.ts
+++ b/lib/api/functions/leagueFn.ts
@@ -62,7 +62,6 @@ export const getLeagueCheck = async (
   clubId: string,
   leagueId: string,
 ): Promise<GetLeagueCheckResponse> => {
-  console.log("gd");
   return restClient.get<GetLeagueCheckResponse>(
     `/clubs/${clubId}/leagues/${leagueId}/check`,
   );

--- a/lib/api/functions/matchFn.ts
+++ b/lib/api/functions/matchFn.ts
@@ -1,7 +1,8 @@
-import type { GetMatchesResponse } from "@/types/matchTypes";
-import restClient from "../restClient";
-
-const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}`;
+import restClient from "@/lib/api/restClient";
+import type {
+  GetMatchesResponse,
+  PostMatchesResponse,
+} from "@/types/matchTypes";
 
 export const getMatches = async (
   clubId: string,
@@ -15,18 +16,8 @@ export const getMatches = async (
 export const postMatches = async (
   clubId: string,
   leagueId: string,
-): Promise<string> => {
-  const response = await fetch(
-    `${BASE_URL}/clubs/${clubId}/leagues/${leagueId}/matches`,
-    {
-      method: "POST",
-      credentials: "include",
-    },
+): Promise<PostMatchesResponse> => {
+  return restClient.post<PostMatchesResponse>(
+    `/clubs/${clubId}/leagues/${leagueId}/matches`,
   );
-
-  if (!response.ok) {
-    throw new Error("대진표 생성에 실패했습니다.");
-  }
-
-  return response.text();
 };

--- a/lib/api/hooks/leagueHook.ts
+++ b/lib/api/hooks/leagueHook.ts
@@ -1,3 +1,16 @@
+import {
+  deleteLeagues,
+  deleteParticipateLeague,
+  getDateLeague,
+  getLeagueCheck,
+  getLeagueDetail,
+  getMonthLeagues,
+  patchLeague,
+  postLeague,
+  postParticipateLeague,
+} from "@/lib/api/functions/leagueFn";
+import useMutationWithToast from "@/lib/api/hooks/useMutationWithToast";
+import useQueryWithToast from "@/lib/api/hooks/useQueryWithToast";
 import type {
   DeleteLeagueData,
   DeleteLeagueParticipantData,
@@ -10,19 +23,6 @@ import type {
   PostLeagueRequest,
 } from "@/types/leagueTypes";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  deleteLeagues,
-  deleteParticipateLeague,
-  getDateLeague,
-  getLeagueCheck,
-  getLeagueDetail,
-  getMonthLeagues,
-  patchLeague,
-  postLeague,
-  postParticipateLeague,
-} from "../functions/leagueFn";
-import useMutationWithToast from "./useMutationWithToast";
-import useQueryWithToast from "./useQueryWithToast";
 
 export const usePostLeague = (clubId: string, onSuccess: () => void) => {
   const queryClient = useQueryClient();
@@ -123,13 +123,18 @@ export const usePatchLeague = (clubId: string, leagueId: string) => {
   });
 };
 
-export const useDeleteLeague = (clubId: string, leagueId: string) => {
+export const useDeleteLeague = (
+  clubId: string,
+  leagueId: string,
+  onSuccess: () => void,
+) => {
   const queryClient = useQueryClient();
 
   const mutationFn = () => deleteLeagues(clubId, leagueId);
 
   const onSuccessCallback = () => {
     queryClient.invalidateQueries({ queryKey: ["leagueDetailData"] });
+    onSuccess();
   };
 
   return useMutationWithToast<DeleteLeagueData, void>(

--- a/lib/api/hooks/matchHook.ts
+++ b/lib/api/hooks/matchHook.ts
@@ -1,7 +1,8 @@
 import { getMatches, postMatches } from "@/lib/api/functions/matchFn";
 import useQueryWithToast from "@/lib/api/hooks/useQueryWithToast";
-import type { GetMatchesData } from "@/types/matchTypes";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { GetMatchesData, PostMatchesData } from "@/types/matchTypes";
+import { useQueryClient } from "@tanstack/react-query";
+import useMutationWithToast from "./useMutationWithToast";
 
 export const useGetMatches = (clubId: string, leagueId: number) => {
   return useQueryWithToast<GetMatchesData>(["matchesData"], () =>
@@ -9,15 +10,22 @@ export const useGetMatches = (clubId: string, leagueId: number) => {
   );
 };
 
-export const usePostMatches = (clubId: string, leagueId: string) => {
+export const usePostMatches = (
+  clubId: string,
+  leagueId: string,
+  onSuccess: () => void,
+) => {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: () => postMatches(clubId, leagueId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["matchesData"] });
-      queryClient.invalidateQueries({ queryKey: ["leagueDetailData"] });
-    },
-    onError: (error: Error) => alert(error),
-  });
+  const mutationFn = () => postMatches(clubId, leagueId);
+
+  const onSuccessCallback = () => {
+    queryClient.invalidateQueries({ queryKey: ["matchesData"] });
+    queryClient.invalidateQueries({ queryKey: ["leagueDetailData"] });
+    onSuccess();
+  };
+  return useMutationWithToast<PostMatchesData, void>(
+    mutationFn,
+    onSuccessCallback,
+  );
 };

--- a/types/commonTypes.ts
+++ b/types/commonTypes.ts
@@ -1,0 +1,9 @@
+export type Tier = "GOLD" | "SILVER" | "BRONZE" | undefined;
+
+export type LeagueStatus =
+  | "ALL"
+  | "RECRUITING"
+  | "RECRUITING_COMPLETED"
+  | "PLAYING"
+  | "CANCELED"
+  | "FINISHED";

--- a/types/leagueTypes.ts
+++ b/types/leagueTypes.ts
@@ -52,13 +52,3 @@ export type DeleteLeagueParticipantResponse =
 
 export type DeleteLeagueParticipantData =
   components["schemas"]["LeagueParticipationCancelResponse"];
-
-export type TierLimit = "GOLD" | "SILVER" | "BRONZE";
-
-export type LeagueStatus =
-  | "ALL"
-  | "RECRUITING"
-  | "RECRUITING_COMPLETED"
-  | "PLAYING"
-  | "CANCELED"
-  | "FINISHED";

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -5,4 +5,9 @@ export type GetMatchesResponse =
 
 export type GetMatchesData = components["schemas"]["BracketResponse"];
 
+export type PostMatchesResponse =
+  components["schemas"]["CommonResponseBracketResponse"];
+
+export type PostMatchesData = components["schemas"]["BracketResponse"];
+
 export type MatchParticipant = components["schemas"]["Participant"];


### PR DESCRIPTION
- Close #252

## What is this PR? 🔍

- 기능 : 경기 참여 로직 수정
- issue : #252

## Changes 📝
- 경기 참여 버튼, 대진표 생성 버튼을 컴포넌트로 분리하였습니다. 
- 경기 참여 버튼이 보이는 경우의 수를 적용하였습니다. 
  ParticipateButton 컴포넌트의 경우의 수는 `league`의 상태와 사용자 관련 조건(`loginedUser`,`isParticipating`, 티어 비교 등`)에 따라 버튼이 다르게 렌더링됩니다. 아래는 모든 경우의 수를 정리한 것입니다
- 사용자가 참여할 수 있는 경우
   - **조건**:
    사용자가 로그인 상태이고,
    리그 상태가 "RECRUITING" 또는 "RECRUITING_COMPLETED"이고,
    모집 인원이 가득 차지 않았으며,
    사용자의 티어가 리그 요구사항에 부합하고,
    사용자가 아직 참여하지 않은 경우.
    **결과**: "경기 참가" 버튼이 렌더링됩니다. 버튼 클릭 시 `handleParticipate(false)`가 호출됩니다.

- 대진표 생성 버튼이 보이는 경우의 수를 적용하였습니다. 
 - 리그 상태가 RECRUITING_COMPLETED 또는 PLAYING이고,
대진표가 생성되지 않은 경우, "대진표 생성" 버튼을 렌더링.
  - 대진표가 생성된 경우, "대진표 보기" 버튼을 렌더링.
- toast hook이 적용되어 있지 않은 fetch로직을 적용하도록 바꾸었습니다. 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
