### PR TITLE
fix: 경기 생성 시간 관련 에러 처리 

### DIFF
--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -12,6 +12,11 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -27,11 +32,6 @@ import type {
 } from "@/types/leagueTypes";
 import leagueFormSchema from "@/validations/leagueFormSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@radix-ui/react-popover";
 import { endOfDay } from "date-fns";
 import { format, formatISO, setHours, setMinutes } from "date-fns";
 import { ko } from "date-fns/locale";

--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -62,9 +62,9 @@ interface LeagueFormProps {
 function LeagueForm(props: LeagueFormProps) {
   const { clubId, leagueId, initialData } = props;
   const router = useRouter();
-  const [leagueAtDate, setLeagueAtDate] = useState<Date | string>();
+  const [leagueAtDate, setLeagueAtDate] = useState<Date | string>(new Date());
   const [leagueTimeValue, setLeagueTimeValue] = useState<string>("00:00");
-  const [closedAtDate, setClosedAtDate] = useState<Date | string>();
+  const [closedAtDate, setClosedAtDate] = useState<Date | string>(new Date());
   const [closedTimeValue, setClosedTimeValue] = useState<string>("00:00");
 
   const postLeagueOnSuccess = () => router.push(`/club/${clubId}/league`);
@@ -108,17 +108,12 @@ function LeagueForm(props: LeagueFormProps) {
     const [hours, minutes] = time.split(":").map(Number);
 
     if (fieldName === "league_at") {
-      if (!leagueAtDate) {
-        setLeagueTimeValue(time);
-        return;
-      }
       if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
         const newDate = setHours(
           setMinutes(leagueAtDate, minutes ?? 0),
           hours ?? 0,
         );
 
-        console.log(newDate);
         const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
           " ",
           "T",
@@ -129,10 +124,6 @@ function LeagueForm(props: LeagueFormProps) {
       }
     }
     if (fieldName === "recruiting_closed_at") {
-      if (!closedAtDate) {
-        setClosedTimeValue(time);
-        return;
-      }
       if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
         const newDate = setHours(
           setMinutes(closedAtDate, minutes ?? 0),
@@ -238,12 +229,13 @@ function LeagueForm(props: LeagueFormProps) {
                       <Calendar
                         mode="single"
                         selected={
-                          leagueAtDate ? new Date(leagueAtDate) : new Date()
+                          leagueAtDate ? new Date(leagueAtDate) : undefined
                         }
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
                             setLeagueAtDate(selectedDate);
                             form.setValue("league_at", selectedDate.toString());
+                            setLeagueTimeValue("00:00");
                           }
                         }}
                         locale={ko}
@@ -438,7 +430,7 @@ function LeagueForm(props: LeagueFormProps) {
                       <Calendar
                         mode="single"
                         selected={
-                          closedAtDate ? new Date(closedAtDate) : new Date()
+                          closedAtDate ? new Date(closedAtDate) : undefined
                         }
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
@@ -447,6 +439,7 @@ function LeagueForm(props: LeagueFormProps) {
                               "recruiting_closed_at",
                               selectedDate.toString(),
                             );
+                            setClosedTimeValue("00:00");
                           }
                         }}
                         locale={ko}

--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -62,9 +62,9 @@ interface LeagueFormProps {
 function LeagueForm(props: LeagueFormProps) {
   const { clubId, leagueId, initialData } = props;
   const router = useRouter();
-  const [leagueAtDate, setLeagueAtDate] = useState<Date | string>("");
+  const [leagueAtDate, setLeagueAtDate] = useState<Date | string>();
   const [leagueTimeValue, setLeagueTimeValue] = useState<string>("00:00");
-  const [closedAtDate, setClosedAtDate] = useState<Date | string>("");
+  const [closedAtDate, setClosedAtDate] = useState<Date | string>();
   const [closedTimeValue, setClosedTimeValue] = useState<string>("00:00");
 
   const postLeagueOnSuccess = () => router.push(`/club/${clubId}/league`);
@@ -110,12 +110,15 @@ function LeagueForm(props: LeagueFormProps) {
     if (fieldName === "league_at") {
       if (!leagueAtDate) {
         setLeagueTimeValue(time);
+        return;
       }
       if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
         const newDate = setHours(
           setMinutes(leagueAtDate, minutes ?? 0),
           hours ?? 0,
         );
+
+        console.log(newDate);
         const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
           " ",
           "T",
@@ -128,10 +131,11 @@ function LeagueForm(props: LeagueFormProps) {
     if (fieldName === "recruiting_closed_at") {
       if (!closedAtDate) {
         setClosedTimeValue(time);
+        return;
       }
       if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
         const newDate = setHours(
-          setMinutes(leagueAtDate, minutes ?? 0),
+          setMinutes(closedAtDate, minutes ?? 0),
           hours ?? 0,
         );
         const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
@@ -189,7 +193,7 @@ function LeagueForm(props: LeagueFormProps) {
           )}
         />
 
-        <div className="grid grid-cols-2 gap-4 gap-y-8">
+        <div className="grid gap-4 md:grid-cols-2">
           <FormField
             control={form.control}
             name="league_at"
@@ -218,7 +222,7 @@ function LeagueForm(props: LeagueFormProps) {
                           : "경기 시간 선택"}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent className="w-auto p-4 bg-white border rounded-md shadow-md">
+                    <PopoverContent className="w-auto max-w-xs">
                       <Input
                         type="time"
                         value={leagueTimeValue}
@@ -234,7 +238,7 @@ function LeagueForm(props: LeagueFormProps) {
                       <Calendar
                         mode="single"
                         selected={
-                          leagueAtDate ? new Date(leagueAtDate) : undefined
+                          leagueAtDate ? new Date(leagueAtDate) : new Date()
                         }
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
@@ -418,7 +422,7 @@ function LeagueForm(props: LeagueFormProps) {
                           : "모집 마감 시간 선택"}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent className="w-auto p-4 bg-white border rounded-md shadow-md">
+                    <PopoverContent className="w-auto max-w-xs">
                       <Input
                         type="time"
                         value={closedTimeValue}
@@ -434,7 +438,7 @@ function LeagueForm(props: LeagueFormProps) {
                       <Calendar
                         mode="single"
                         selected={
-                          closedAtDate ? new Date(closedAtDate) : undefined
+                          closedAtDate ? new Date(closedAtDate) : new Date()
                         }
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
@@ -497,7 +501,7 @@ function LeagueForm(props: LeagueFormProps) {
         </div>
 
         <div className="flex justify-center pt-8 gap-4">
-          <Button size="lg" className="w-1/4 p-3 font-semibold">
+          <Button size="lg" className="w-1/4 md:w-1/3 p-3 font-semibold">
             {initialData ? "경기 수정" : "경기 생성"}
           </Button>
         </div>

--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -112,9 +112,13 @@ function LeagueForm(props: LeagueFormProps) {
     const [hours, minutes] = time.split(":").map(Number);
     if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
       const newDate = setHours(setMinutes(date, minutes ?? 0), hours ?? 0);
-      setDate(newDate);
+      const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
+        " ",
+        "T",
+      );
+      setDate(formattedDate);
       setTimeValue(time);
-      setValue(fieldName, newDate.toString());
+      setValue(fieldName, formattedDate);
     }
   };
 
@@ -125,7 +129,7 @@ function LeagueForm(props: LeagueFormProps) {
   ) => {
     const closingDate = endOfDay(selectedDate);
     setClosedAt(formatISO(closingDate));
-    setValue(fieldName, closingDate.toString());
+    setValue(fieldName, closingDate.toISOString());
   };
 
   return (
@@ -402,7 +406,7 @@ function LeagueForm(props: LeagueFormProps) {
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
                             handleClosedAtSelect(
-                              selectedDate.toString(),
+                              selectedDate.toISOString(),
                               form.setValue,
                               "recruiting_closed_at",
                             );

--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -63,7 +63,7 @@ interface LeagueFormProps {
 function LeagueForm(props: LeagueFormProps) {
   const { clubId, leagueId, initialData } = props;
   const router = useRouter();
-  const [date, setDate] = useState<Date>();
+  const [date, setDate] = useState<Date | string>();
   const [timeValue, setTimeValue] = useState<string>("00:00");
   const [closedAt, setClosedAt] = useState<string>("");
 
@@ -114,18 +114,18 @@ function LeagueForm(props: LeagueFormProps) {
       const newDate = setHours(setMinutes(date, minutes ?? 0), hours ?? 0);
       setDate(newDate);
       setTimeValue(time);
-      setValue(fieldName, newDate.toISOString());
+      setValue(fieldName, newDate.toString());
     }
   };
 
   const handleClosedAtSelect = (
-    selectedDate: Date,
+    selectedDate: string,
     setValue: UseFormSetValue<LeagueFormRequest>,
     fieldName: Path<LeagueFormRequest>,
   ) => {
     const closingDate = endOfDay(selectedDate);
     setClosedAt(formatISO(closingDate));
-    setValue(fieldName, closingDate.toISOString());
+    setValue(fieldName, closingDate.toString());
   };
 
   return (
@@ -219,10 +219,7 @@ function LeagueForm(props: LeagueFormProps) {
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
                             setDate(selectedDate);
-                            form.setValue(
-                              "league_at",
-                              selectedDate.toISOString(),
-                            );
+                            form.setValue("league_at", selectedDate.toString());
                           }
                         }}
                         locale={ko}
@@ -403,7 +400,7 @@ function LeagueForm(props: LeagueFormProps) {
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
                             handleClosedAtSelect(
-                              selectedDate,
+                              selectedDate.toString(),
                               form.setValue,
                               "recruiting_closed_at",
                             );

--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -216,6 +216,7 @@ function LeagueForm(props: LeagueFormProps) {
                       />
                       <Calendar
                         mode="single"
+                        selected={date ? new Date(date) : undefined}
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
                             setDate(selectedDate);
@@ -224,6 +225,7 @@ function LeagueForm(props: LeagueFormProps) {
                         }}
                         locale={ko}
                         className="text-black"
+                        disabled={{ before: new Date() }}
                       />
                     </PopoverContent>
                   </Popover>
@@ -408,6 +410,7 @@ function LeagueForm(props: LeagueFormProps) {
                         }}
                         locale={ko}
                         className="text-black"
+                        disabled={{ before: new Date() }}
                       />
                     </PopoverContent>
                   </Popover>

--- a/components/pages/club/LeagueCreate.tsx
+++ b/components/pages/club/LeagueCreate.tsx
@@ -6,7 +6,7 @@ import { useParams } from "next/navigation";
 function LeagueCreate() {
   const { clubId, leagueId } = useParams();
   return (
-    <div className="container mx-auto rounded-lg space-y-6 ">
+    <div className="container mx-auto rounded-lg space-y-6 p-6">
       <div className="border-b pb-4">
         <h2 className="text-2xl font-bold text-gray-800">경기 생성</h2>
       </div>

--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -196,7 +196,10 @@ function LeagueDetail() {
           label="모집 마감 일자"
           value={
             league?.recruiting_closed_at &&
-            format(new Date(league.recruiting_closed_at), "yyyy-MM-dd")
+            format(
+              new Date(league.recruiting_closed_at),
+              "yyyy-MM-dd HH시 mm분",
+            )
           }
         />
 

--- a/components/pages/club/LeagueUpdate.tsx
+++ b/components/pages/club/LeagueUpdate.tsx
@@ -12,7 +12,7 @@ function LeagueUpdate() {
   );
 
   return (
-    <div className="container mx-auto rounded-lg space-y-6 ">
+    <div className="container mx-auto rounded-lg space-y-6 lg:p-6 md:p-4 p-3">
       <div className="border-b pb-4">
         <h2 className="text-2xl font-bold text-gray-800">경기 수정</h2>
       </div>


### PR DESCRIPTION
- Close #299

## What is this PR? 🔍

- 기능 : 경기 생성 시간 관련 에러 처리
- issue : #299

## Changes 📝
- 경기 시간 이상하게 나오는 에러 해결
  - 경기 시간을 한국 시간에 맞게 보내주는 것으로 처리했습니다. 
- 모집 마감 시간 까지 선택할 수 있게 해결
- 이전 시간은 선택 안되도록 막기
  - 오늘 이전의 날짜는 선택 못하도록 막았습니다. 
-  경기 모집 마감 시간 시간까지 보여주기
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/98af5a8f-035f-4cac-911a-349837bffb7c)
![image](https://github.com/user-attachments/assets/61399be0-2d70-4d36-be9d-2c01f428e466)
![image](https://github.com/user-attachments/assets/cf92b125-c726-4e08-9b7d-440db8e2bd40)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
