### PR TITLE
feat: 메인 페이지 ui 추가

### DIFF
--- a/components/liveMatch/LeagueStatusButton.tsx
+++ b/components/liveMatch/LeagueStatusButton.tsx
@@ -56,7 +56,7 @@ function LeagueStatusButton(props: LeagueStatusButtonProps) {
   if (status === "FINISHED") {
     return (
       <Link href={`/club/${clubToken}/league/${leagueId}`}>
-        <Button className="p-2 h-8 rounded-md text-xs w-[105px] border-primary hover:border-primary hover:text-primay hover:bg-white">
+        <Button className="p-2 h-8 rounded-md text-xs w-[105px] border border-gray-600 text-gray-600 bg-white hover:bg-white hover:text-gray-600">
           종료된 경기
         </Button>
       </Link>

--- a/components/pages/LiveMatchList.tsx
+++ b/components/pages/LiveMatchList.tsx
@@ -3,13 +3,14 @@
 import DateCarousel from "@/components/DayCarousel";
 import MainBannerCarousel from "@/components/MainBannerCarousel";
 import Spinner from "@/components/Spinner";
+import LeagueStatusButton from "@/components/liveMatch/LeagueStatusButton";
+import LeagueTierBadge from "@/components/liveMatch/TierBadge";
 import { Button } from "@/components/ui/Button";
 import SImage from "@/components/ui/Image";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
-  AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
@@ -24,8 +25,6 @@ import type {
 import { format } from "date-fns";
 import Link from "next/link";
 import React, { useState } from "react";
-import LeagueStatusButton from "../liveMatch/LeagueStatusButton";
-import LeagueTierBadge from "../liveMatch/TierBadge";
 
 function LiveMatchList() {
   const today = format(new Date(), "yyyy-MM-dd");
@@ -63,6 +62,11 @@ function LiveMatchList() {
           {isLoading ? (
             <div>
               <Spinner />
+            </div>
+          ) : data.length === 0 ? (
+            <div className="w-full min-h-[25vh] col-span-1 sm:col-span-2 lg:col-span-3  flex flex-col justify-center items-center gap-2 text-black">
+              <img src="/images/logo.png" alt="logo" className="w-24 h-24" />
+              예정된 경기가 없습니다
             </div>
           ) : (
             <Accordion


### PR DESCRIPTION
- Close #302

## What is this PR? 🔍

- 기능 : 메인 페이지 ui 추가
- issue : #302

## Changes 📝
- 경기 없을 때 처리
- 종료된 경기 ui 에러 처리
  - 종료된 경기 버튼이 모집중인 경우 버튼과 ui 가 같아서 border 가 있는 버튼으로 변경함
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/a913a342-4363-496c-b94c-cd6f2183537c)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
