### PR TITLE
fix: 시간 선택 안하면 fetch 안되는 오류 해결

### DIFF
--- a/components/club/LeagueForm.tsx
+++ b/components/club/LeagueForm.tsx
@@ -108,35 +108,31 @@ function LeagueForm(props: LeagueFormProps) {
     const [hours, minutes] = time.split(":").map(Number);
 
     if (fieldName === "league_at") {
-      if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
-        const newDate = setHours(
-          setMinutes(leagueAtDate, minutes ?? 0),
-          hours ?? 0,
-        );
+      const newDate = setHours(
+        setMinutes(leagueAtDate, minutes ?? 0),
+        hours ?? 0,
+      );
 
-        const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
-          " ",
-          "T",
-        );
-        setLeagueAtDate(formattedDate);
-        setLeagueTimeValue(time);
-        setValue(fieldName, formattedDate);
-      }
+      const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
+        " ",
+        "T",
+      );
+      setLeagueAtDate(formattedDate);
+      setLeagueTimeValue(time);
+      setValue(fieldName, formattedDate);
     }
     if (fieldName === "recruiting_closed_at") {
-      if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
-        const newDate = setHours(
-          setMinutes(closedAtDate, minutes ?? 0),
-          hours ?? 0,
-        );
-        const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
-          " ",
-          "T",
-        );
-        setClosedAtDate(formattedDate);
-        setClosedTimeValue(time);
-        setValue(fieldName, formattedDate);
-      }
+      const newDate = setHours(
+        setMinutes(closedAtDate, minutes ?? 0),
+        hours ?? 0,
+      );
+      const formattedDate = format(newDate, "yyyy-MM-dd kk:mm:00").replace(
+        " ",
+        "T",
+      );
+      setClosedAtDate(formattedDate);
+      setClosedTimeValue(time);
+      setValue(fieldName, formattedDate);
     }
   };
 
@@ -233,8 +229,12 @@ function LeagueForm(props: LeagueFormProps) {
                         }
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
-                            setLeagueAtDate(selectedDate);
-                            form.setValue("league_at", selectedDate.toString());
+                            const formattedDate = format(
+                              selectedDate,
+                              "yyyy-MM-dd kk:mm:00",
+                            ).replace(" ", "T");
+                            setLeagueAtDate(formattedDate);
+                            form.setValue("league_at", formattedDate);
                             setLeagueTimeValue("00:00");
                           }
                         }}
@@ -434,12 +434,16 @@ function LeagueForm(props: LeagueFormProps) {
                         }
                         onSelect={(selectedDate) => {
                           if (selectedDate) {
-                            setClosedAtDate(selectedDate);
+                            const formattedDate = format(
+                              selectedDate,
+                              "yyyy-MM-dd kk:mm:00",
+                            ).replace(" ", "T");
+                            setLeagueAtDate(formattedDate);
                             form.setValue(
                               "recruiting_closed_at",
-                              selectedDate.toString(),
+                              formattedDate,
                             );
-                            setClosedTimeValue("00:00");
+                            setLeagueTimeValue("00:00");
                           }
                         }}
                         locale={ko}


### PR DESCRIPTION
- Close #311

## What is this PR? 🔍

- 기능 : 시간 선택 안하면 fetch 안되는 오류 해결
- issue : #311

## Changes 📝
- 백엔드에 데이터를 전달하려면, 올바른 형식에 맞춰서 보내주어야 합니다. 기존에는 이에 대한 처리 함수로 구현했는데, 이 함수는 시간 input을 선택해야만 동작했습니다. 
- 캘린더에서 날짜 선택할 때도 기본적으로 formatting 된 값을 저장하도록 처리했습니다. 
 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
### 중복 코드가 많아, 리팩토링이 필요합니다
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
