### PR TITLE
feat: 대진표 생성 버튼 조건 맞지 않으면 비활성화

### DIFF
--- a/components/club/LeagueDetail/MatchButton.tsx
+++ b/components/club/LeagueDetail/MatchButton.tsx
@@ -5,17 +5,18 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { usePostMatches } from "@/lib/api/hooks/matchHook";
 import type { GetLeagueDetailData } from "@/types/leagueTypes";
 import type { GetMemberSessionData } from "@/types/memberTypes";
 import { BookUser } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 interface MatchButtonProps {
   clubId: string;
   leagueId: string;
   league: GetLeagueDetailData;
   loginedUser: GetMemberSessionData;
-  createMatch: () => void; // 대진표 생성 함수 타입 정의
 }
 
 const MatchButton = ({
@@ -23,12 +24,23 @@ const MatchButton = ({
   clubId,
   league,
   loginedUser,
-  createMatch,
 }: MatchButtonProps) => {
+  const router = useRouter();
+
   const matchCreateCondition =
     (league.league_status === "RECRUITING_COMPLETED" ||
       league.league_status === "PLAYING") &&
     !league?.is_match_created;
+
+  const createMatchOnSuccess = () => {
+    router.push(`/club/${clubId}/league/${leagueId}/match`);
+  };
+
+  const { mutate: createMatch } = usePostMatches(
+    clubId as string,
+    leagueId as string,
+    () => createMatchOnSuccess(),
+  );
 
   if (league.is_match_created) {
     return (
@@ -56,7 +68,12 @@ const MatchButton = ({
             <Button
               size="lg"
               variant="outline"
-              className="items-center justify-center gap-2 border-primary w-full hover:bg-white hover:text-primary"
+              className={`items-center justify-center gap-2 w-full 
+                ${
+                  matchCreateCondition
+                    ? "border-primary hover:bg-white hover:text-primary"
+                    : "cursor-not-allowed border-zinc-300 text-zinc-500 hover:bg-white hover:text-zinc-500"
+                }`}
               onClick={() => {
                 if (matchCreateCondition) {
                   createMatch();

--- a/components/pages/club/LeagueDetail.tsx
+++ b/components/pages/club/LeagueDetail.tsx
@@ -14,7 +14,6 @@ import {
   useGetLeagueCheck,
   useGetLeagueDetail,
 } from "@/lib/api/hooks/leagueHook";
-import { usePostMatches } from "@/lib/api/hooks/matchHook";
 import { useGetMembersSession } from "@/lib/api/hooks/memberHook";
 import { getTierWithEmojiAndText } from "@/utils/getTier";
 import { format } from "date-fns";
@@ -54,7 +53,6 @@ const getRecruitmentStatusLabel = (status: string) => {
 
 function LeagueDetail() {
   const { clubId, leagueId } = useParams();
-  const router = useRouter();
   const { data: league, isLoading } = useGetLeagueDetail(
     clubId as string,
     leagueId as string,
@@ -69,11 +67,6 @@ function LeagueDetail() {
     clubId as string,
     leagueId as string,
     () => alert("경기 취소가 완료되었습니다"),
-  );
-  const { mutate: createMatch } = usePostMatches(
-    clubId as string,
-    leagueId as string,
-    () => router.push(`/club/${clubId}/league/${leagueId}/match`),
   );
 
   const cancelLeague = () => {
@@ -226,7 +219,6 @@ function LeagueDetail() {
             leagueId={leagueId as string}
             league={league}
             loginedUser={loginedUser?.data}
-            createMatch={createMatch}
           />
         )}
         {league && loginedUser && (


### PR DESCRIPTION
- Close #319
## What is this PR? 🔍

- 기능 : 대진표 생성 버튼 조건 맞지 않으면 비활성화
- issue : #319

## Changes 📝
- 대진표 생성 조건이 맞지 않으면, 비활성화 처리를 하였습니다.
- 버튼의 props 를 줄이고, 컴포넌트 내에서 fetch 처리 하도록 했습니다. 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/9cc2ef04-c2a2-454f-91f0-ff0f66f2185e)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
