### PR TITLE
feat: 프리 대진표에서 스코어페이지 연결 및 대진표 반응형 고려

### DIFF
--- a/components/club/FreeBracket/MatchCard.tsx
+++ b/components/club/FreeBracket/MatchCard.tsx
@@ -1,0 +1,203 @@
+import SImage from "@/components/ui/Image";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { DoublesMatchType, SinglesMatchType } from "@/types/matchTypes";
+import Link from "next/link";
+
+interface MatchCardProps {
+  clubId: string;
+  leagueId: string;
+  isDouble: boolean;
+  match: SinglesMatchType | DoublesMatchType;
+}
+
+function MatchCard(props: MatchCardProps) {
+  const { match, clubId, leagueId, isDouble } = props;
+  return (
+    <Link
+      key={match.match_id}
+      className="flex flex-col gap-6 sm:gap-8"
+      href={`/club/${clubId}/league/${leagueId}/match/${match.match_id}`}
+    >
+      <Badge className="bg-yellow-500 hover:bg-yellow-500 text-xs font-semibold text-center mb-2 rounded-sm flex justify-center">
+        round {match.round_number}
+      </Badge>
+      <div className="flex flex-col items-center gap-4 sm:gap-6">
+        <div className="w-full flex flex-wrap justify-center gap-2 sm:gap-4">
+          <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
+            <SImage
+              src={
+                isDouble
+                  ? (match as DoublesMatchType).team1?.participant1?.image ||
+                    "/images/dummy-image.jpg"
+                  : (match as SinglesMatchType).participant1?.image ||
+                    "/images/dummy-image.jpg"
+              }
+              radius="circular"
+              width={50}
+              height={50}
+              alt={
+                isDouble
+                  ? (match as DoublesMatchType).team1?.participant1?.name ||
+                    "participant"
+                  : (match as SinglesMatchType).participant1?.name ||
+                    "participant"
+              }
+            />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                    {isDouble
+                      ? (match as DoublesMatchType).team1?.participant1?.name ||
+                        ""
+                      : (match as SinglesMatchType).participant1?.name || ""}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    {isDouble
+                      ? (match as DoublesMatchType).team1?.participant1?.name
+                      : (match as SinglesMatchType).participant1?.name}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          {isDouble && (
+            <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
+              <SImage
+                src={
+                  (match as DoublesMatchType).team1?.participant2?.image ||
+                  "/images/dummy-image.jpg"
+                }
+                radius="circular"
+                width={50}
+                height={50}
+                alt={
+                  (match as DoublesMatchType).team1?.participant2?.name ||
+                  "participant"
+                }
+              />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                      {(match as DoublesMatchType).team1?.participant2?.name ||
+                        ""}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      {(match as DoublesMatchType).team1?.participant2?.name}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          )}
+        </div>
+        <div className="w-full flex flex-col items-center justify-center gap-2 text-xl font-semibold text-gray-900">
+          <span>
+            {isDouble
+              ? (match as DoublesMatchType).team1?.team1_win_set_count || 0
+              : (match as SinglesMatchType).participant1
+                  ?.participant_win_set_count || 0}
+          </span>
+          <Separator className="my-2" />
+          <span>
+            {isDouble
+              ? (match as DoublesMatchType).team2?.team1_win_set_count || 0
+              : (match as SinglesMatchType).participant2
+                  ?.participant_win_set_count || 0}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-4 sm:gap-6">
+        <div className="w-full flex flex-wrap justify-center gap-2 sm:gap-4">
+          <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
+            <SImage
+              src={
+                isDouble
+                  ? (match as DoublesMatchType).team2?.participant1?.image ||
+                    "/images/dummy-image.jpg"
+                  : (match as SinglesMatchType).participant2?.image ||
+                    "/images/dummy-image.jpg"
+              }
+              radius="circular"
+              width={50}
+              height={50}
+              alt={
+                isDouble
+                  ? (match as DoublesMatchType).team2?.participant1?.name ||
+                    "participant"
+                  : (match as SinglesMatchType).participant2?.name ||
+                    "participant"
+              }
+            />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                    {isDouble
+                      ? (match as DoublesMatchType).team2?.participant1?.name ||
+                        ""
+                      : (match as SinglesMatchType).participant2?.name || ""}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    {isDouble
+                      ? (match as DoublesMatchType).team2?.participant1?.name
+                      : (match as SinglesMatchType).participant2?.name}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          {isDouble && (
+            <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
+              <SImage
+                src={
+                  (match as DoublesMatchType).team2?.participant2?.image ||
+                  "/images/dummy-image.jpg"
+                }
+                radius="circular"
+                width={50}
+                height={50}
+                alt={
+                  (match as DoublesMatchType).team2?.participant2?.name ||
+                  "participant"
+                }
+              />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                      {(match as DoublesMatchType).team2?.participant2?.name ||
+                        ""}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      {(match as DoublesMatchType).team2?.participant2?.name}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default MatchCard;

--- a/components/club/FreeBracket/index.tsx
+++ b/components/club/FreeBracket/index.tsx
@@ -1,6 +1,12 @@
 import SImage from "@/components/ui/Image";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { GetMatchesData } from "@/types/matchTypes";
 import React from "react";
 
@@ -57,6 +63,9 @@ function FreeBracket(props: FreeBracketProps) {
       {nodeData.match_type === "DOUBLES" &&
         nodeData.doubles_match_response_list?.map((match) => (
           <div key={match.match_id} className="flex flex-col gap-8">
+            <Badge className="bg-yellow-500 hover:bg-yellow-500 text-xs font-semibold text-center mb-2 rounded-sm flex justify-center">
+              round {match.round_number}
+            </Badge>
             <div className="flex flex-col items-center gap-6">
               <div className="w-full flex flex-wrap justify-center gap-4">
                 <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
@@ -70,9 +79,18 @@ function FreeBracket(props: FreeBracketProps) {
                     height={50}
                     alt={match.team1.participant1.name}
                   />
-                  <span className="text-gray-800 text-sm font-semibold truncate">
-                    {match.team1.participant1.name}
-                  </span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                          {match.team1.participant1.name || ""}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{match.team1.participant1.name}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
                 <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
                   <SImage
@@ -85,9 +103,18 @@ function FreeBracket(props: FreeBracketProps) {
                     height={50}
                     alt={match.team1.participant2.name}
                   />
-                  <span className="text-gray-800 text-sm font-semibold truncate">
-                    {match.team1.participant2.name}
-                  </span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                          {match.team1.participant2.name || ""}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{match.team1.participant2.name}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </div>
               <div className="w-full flex flex-col items-center justify-center gap-2 text-xl font-semibold text-gray-900">
@@ -110,10 +137,20 @@ function FreeBracket(props: FreeBracketProps) {
                     height={50}
                     alt={match.team2.participant1.name}
                   />
-                  <span className="text-gray-800 text-sm font-semibold truncate">
-                    {match.team2.participant1.name}
-                  </span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                          {match.team2.participant1.name || ""}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{match.team2.participant1.name}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
+
                 <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
                   <SImage
                     src={
@@ -125,9 +162,18 @@ function FreeBracket(props: FreeBracketProps) {
                     height={50}
                     alt={match.team2.participant2.name}
                   />
-                  <span className="text-gray-800 text-sm font-semibold truncate">
-                    {match.team2.participant2.name}
-                  </span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
+                          {match.team2.participant2.name || ""}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{match.team2.participant2.name}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </div>
             </div>

--- a/components/club/FreeBracket/index.tsx
+++ b/components/club/FreeBracket/index.tsx
@@ -1,14 +1,6 @@
-import SImage from "@/components/ui/Image";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import type { GetMatchesData } from "@/types/matchTypes";
-import React from "react";
+import { useParams } from "next/navigation";
+import MatchCard from "./MatchCard";
 
 interface FreeBracketProps {
   nodeData: GetMatchesData;
@@ -16,168 +8,29 @@ interface FreeBracketProps {
 
 function FreeBracket(props: FreeBracketProps) {
   const { nodeData } = props;
+  const { clubId, leagueId } = useParams();
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 p-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 p-3 sm:p-4">
       {nodeData.match_type === "SINGLES" &&
         nodeData.singles_match_response_list?.map((match) => (
-          <div
+          <MatchCard
             key={match.match_id}
-            className="p-4 rounded-lg w-full flex flex-col justify-center items-center border border-solid border-gray-300 cursor-pointer"
-          >
-            <Badge className="bg-yellow-500 hover:bg-yellow-500 text-xs font-semibold text-center mb-2 rounded-sm">
-              round {match.round_number}
-            </Badge>
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex items-center space-x-3">
-                <SImage
-                  src={match.participant1?.image || "/images/dummy-image.jpg"}
-                  radius="circular"
-                  width={45}
-                  height={45}
-                  alt="profile"
-                />
-                <span className="text-gray-800 text-sm font-semibold truncate">
-                  {match.participant1?.name}
-                </span>
-              </div>
-              <span className="text-gray-900 font-bold text-lg">
-                {match.participant1?.participant_win_set_count} :{" "}
-                {match.participant2?.participant_win_set_count}
-              </span>
-              <div className="flex items-center space-x-3">
-                <span className="text-gray-800 text-sm font-semibold ">
-                  {match.participant2?.name}
-                </span>
-                <SImage
-                  src={match.participant2?.image || "images/dummy-image.jpg"}
-                  radius="circular"
-                  width={45}
-                  height={45}
-                  alt="profile"
-                />
-              </div>
-            </div>
-          </div>
+            match={match}
+            clubId={clubId as string}
+            leagueId={leagueId as string}
+            isDouble={false}
+          />
         ))}
-
       {nodeData.match_type === "DOUBLES" &&
         nodeData.doubles_match_response_list?.map((match) => (
-          <div key={match.match_id} className="flex flex-col gap-8">
-            <Badge className="bg-yellow-500 hover:bg-yellow-500 text-xs font-semibold text-center mb-2 rounded-sm flex justify-center">
-              round {match.round_number}
-            </Badge>
-            <div className="flex flex-col items-center gap-6">
-              <div className="w-full flex flex-wrap justify-center gap-4">
-                <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
-                  <SImage
-                    src={
-                      match.team1.participant1.image ||
-                      "/images/dummy-image.jpg"
-                    }
-                    radius="circular"
-                    width={50}
-                    height={50}
-                    alt={match.team1.participant1.name}
-                  />
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
-                          {match.team1.participant1.name || ""}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{match.team1.participant1.name}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
-                  <SImage
-                    src={
-                      match.team1.participant2.image ||
-                      "/images/dummy-image.jpg"
-                    }
-                    radius="circular"
-                    width={50}
-                    height={50}
-                    alt={match.team1.participant2.name}
-                  />
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
-                          {match.team1.participant2.name || ""}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{match.team1.participant2.name}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </div>
-              <div className="w-full flex flex-col items-center justify-center gap-2 text-xl font-semibold text-gray-900">
-                <span>{match.team1.team1_win_set_count}</span>
-                <Separator />
-                <span>{match.team2.team1_win_set_count}</span>
-              </div>
-            </div>
-
-            <div className="flex flex-col items-center gap-6">
-              <div className="w-full flex flex-wrap justify-center gap-4">
-                <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
-                  <SImage
-                    src={
-                      match.team2.participant1.image ||
-                      "/images/dummy-image.jpg"
-                    }
-                    radius="circular"
-                    width={50}
-                    height={50}
-                    alt={match.team2.participant1.name}
-                  />
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
-                          {match.team2.participant1.name || ""}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{match.team2.participant1.name}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-
-                <div className="flex flex-col items-center gap-2 w-full sm:w-1/2 lg:w-1/3">
-                  <SImage
-                    src={
-                      match.team2.participant2.image ||
-                      "/images/dummy-image.jpg"
-                    }
-                    radius="circular"
-                    width={50}
-                    height={50}
-                    alt={match.team2.participant2.name}
-                  />
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="text-gray-800 text-sm font-semibold truncate max-w-[5rem] sm:max-w-[7rem] md:max-w-[8rem] block">
-                          {match.team2.participant2.name || ""}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{match.team2.participant2.name}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </div>
-            </div>
-          </div>
+          <MatchCard
+            key={match.match_id}
+            match={match}
+            clubId={clubId as string}
+            leagueId={leagueId as string}
+            isDouble={true}
+          />
         ))}
     </div>
   );

--- a/components/pages/club/Match.tsx
+++ b/components/pages/club/Match.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Spinner from "@/components/Spinner";
 import FreeBracket from "@/components/club/FreeBracket";
 import TournamentBracket from "@/components/club/TournamentBracket";
 import { useGetMatches } from "@/lib/api/hooks/matchHook";
@@ -14,8 +15,8 @@ function Match() {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center h-[464px] w-full">
-        Loading...
+      <div className="container mx-auto  min-h-[530px] flex items-center justify-center bg-white rounded-lg space-y-6">
+        <Spinner />
       </div>
     );
   }

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -52,3 +52,7 @@ export type SetType = {
   score2?: number | undefined;
   set_status?: "NOT_STARTED" | "IN_PROGRESS" | "FINISHED" | undefined;
 };
+
+export type SinglesMatchType = components["schemas"]["SinglesMatchResponse"];
+
+export type DoublesMatchType = components["schemas"]["DoublesMatchResponse"];


### PR DESCRIPTION
- Close #321

## What is this PR? 🔍

- 기능 :  프리 대진표에서 스코어페이지 연결 및 대진표 반응형 고려
- issue : #321

## Changes 📝
-  프리 대진표에서 스코어페이지 연결
- 대진표 반응형 고려
  - 반응형 고려하면서 단식 ui 를 복식 ui와 동일하게 맞춤
  - 컴포넌트로 분리함
  - ui 깨지는 오류 해결
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/6e788217-4f4f-4359-bec9-e01f09b50767)

![image](https://github.com/user-attachments/assets/549615dd-fc2f-421d-9cb6-46c39254b31a)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
