### PR TITLE
fix: 이미지 미리보기 사용자가 올린 사진 url로 세팅하기

### DIFF
--- a/components/club/ClubForm.tsx
+++ b/components/club/ClubForm.tsx
@@ -79,16 +79,17 @@ function ClubForm(props: ClubFormProps) {
   });
 
   const uploadImage = (file: File) => {
+    const previewUrl = URL.createObjectURL(file);
+    setImgUrl(previewUrl);
+
     const formData = new FormData();
     formData.append("multipartFile", file);
-    console.log("2");
+
     createClubImg(formData, {
       onSuccess: (data) => {
         if (data.data) {
-          setImgUrl(data.data || undefined);
           form.setValue("club_image", data.data);
           form.clearErrors("club_image");
-          console.log(data);
         }
       },
       onError: () => {
@@ -111,6 +112,14 @@ function ClubForm(props: ClubFormProps) {
         type: "manual",
         message: "이미지를 다시 업로드하세요",
       });
+    }
+  };
+
+  const handleImageRemove = () => {
+    setImgUrl(undefined);
+    form.setValue("club_image", "");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""; // 파일 입력 값 초기화
     }
   };
 
@@ -145,14 +154,6 @@ function ClubForm(props: ClubFormProps) {
 
     if (initialData) return patchClub(newClubData);
     createClub(newClubData);
-  };
-
-  const handleImageRemove = () => {
-    setImgUrl(undefined);
-    form.setValue("club_image", "");
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ""; // 파일 입력 값 초기화
-    }
   };
 
   return (

--- a/components/pages/myPage/EditProfileDialog.tsx
+++ b/components/pages/myPage/EditProfileDialog.tsx
@@ -69,32 +69,27 @@ function EditProfileDialog({
     const file = e.target.files?.[0];
     if (file) {
       const imageUrl = URL.createObjectURL(file);
-      setProfileImage(imageUrl);
-      setUploadedImageFile(file);
+      setProfileImage(imageUrl); // 미리보기에 반영
+      setUploadedImageFile(file); // 업로드할 파일 설정
+      form.clearErrors("profileImage"); // 기존 에러 제거
+    } else {
+      form.setError("profileImage", {
+        type: "manual",
+        message: "유효한 이미지를 선택하세요.",
+      });
     }
   };
 
   const handleImageRemove = () => {
     // 이미지 삭제 후 기본 이미지 설정
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
-    setProfileImage(DEFAULT_IMAGE!); // 기본 이미지 설정
+    setProfileImage(DEFAULT_IMAGE!); // 기본 이미지로 설정
     setUploadedImageFile(null); // 업로드된 파일 정보 초기화
     form.setValue("profileImage", DEFAULT_IMAGE); // 폼 값도 기본 이미지로 설정
   };
 
   const onSubmit: SubmitHandler<ProfileFormInputs> = (data) => {
     const { name } = data;
-    let profileImageUrl: string;
-
-    // 이미지 삭제 후, 수정할 때 기본 이미지를 설정하는 부분
-    if (uploadedImageFile) {
-      profileImageUrl = profileImage; // 업로드된 이미지 사용
-    } else if (profileImage === DEFAULT_IMAGE) {
-      // biome-ignore lint/style/noNonNullAssertion: <explanation>
-      profileImageUrl = DEFAULT_IMAGE!; // 기본 이미지 사용
-    } else {
-      profileImageUrl = initialProfileImage; // 이름만 수정 시 기존 이미지 그대로 사용
-    }
 
     if (uploadedImageFile) {
       const formData = new FormData();
@@ -110,14 +105,16 @@ function EditProfileDialog({
             });
           }
         },
-        onError: (error) => {
-          console.error("이미지 업로드 실패:", error);
+        onError: () => {
+          alert("이미지 업로드에 실패했습니다. 다시 시도해주세요.");
+          // biome-ignore lint/style/noNonNullAssertion: <explanation>
+          setProfileImage(DEFAULT_IMAGE!);
         },
       });
     } else {
       putProfile({
         name,
-        profile_image_url: profileImageUrl, // 선택된 이미지로 업데이트
+        profile_image_url: profileImage,
       });
     }
   };


### PR DESCRIPTION
- Close #323

## What is this PR? 🔍

- 기능 :이미지 미리보기 사용자가 올린 사진 url로 세팅하기
- issue : #323

## Changes 📝
- 기존은 서버의 데이터 결과로 미리보기를 세팅했습니다. 주소가 response로 보내질 때 그 주소에 이미지 데이터가 늦게 저장 될 가능성이 있다고 백엔드에서 말
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
