### PR TITLE
fix: 동호회 소개 페이지 렌더링 버벅이는 현상 해결

### DIFF
--- a/app/club/[clubId]/page.tsx
+++ b/app/club/[clubId]/page.tsx
@@ -34,6 +34,7 @@ async function ClubIntroPage({ params }: Props) {
   await queryClient.prefetchQuery({
     queryKey: ["clubsDataById", clubId],
     queryFn: () => getClubsById(clubId),
+    staleTime: 1000 * 60 * 1, // stale time은 1분
   });
 
   return (

--- a/lib/api/hooks/clubHook.ts
+++ b/lib/api/hooks/clubHook.ts
@@ -87,10 +87,13 @@ export const usePostClubsImg = () => {
     onError: (error: Error) => alert(error),
   });
 };
-
 export const useGetClubsById = (clubId: string) => {
-  return useQueryWithToast<GetClubDetailData>(["clubsDataById", clubId], () =>
-    getClubsById(clubId),
+  return useQueryWithToast<GetClubDetailData>(
+    ["clubsDataById", clubId],
+    () => getClubsById(clubId),
+    {
+      staleTime: 1000 * 60 * 1, // stale time은 1분
+    },
   );
 };
 

--- a/lib/api/hooks/useQueryWithToast.ts
+++ b/lib/api/hooks/useQueryWithToast.ts
@@ -6,7 +6,8 @@ import { type QueryObserverResult, useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 interface UseQueryWithToastOptions {
-  enabled?: boolean; // enabled 옵션을 옵셔널로 추가
+  enabled?: boolean;
+  staleTime?: number; // 서버 fetching을 위한 staleTime 설정
 }
 
 const useQueryWithToast = <TData>(
@@ -24,6 +25,7 @@ const useQueryWithToast = <TData>(
     queryKey,
     queryFn,
     enabled: options?.enabled ?? true,
+    staleTime: options?.staleTime,
   });
 
   useEffect(() => {

--- a/lib/api/restClient.ts
+++ b/lib/api/restClient.ts
@@ -9,10 +9,12 @@ const restClient = {
         "Content-Type": "application/json",
       },
       credentials: "include",
+      // Note: Next.js의 default fetch caching 전략: 'force-cache' [서버]
+      // https://nextjs.org/docs/14/app/building-your-application/caching#fetch
+      // no-store를 통해서 이전에 서버에서 fetching 하는 것들의 캐싱을 막아줘야 예상 밖의 동작이 일어나지 않는다
+      cache: "no-store",
     });
-    // if (!response.ok) {
-    //   return response.status;
-    // }
+
     const data = await response.json();
     return data as T;
   },


### PR DESCRIPTION
- Close #324

## What is this PR? 🔍

- 기능 : 동호회 소개 렌더링 에러 해결
- issue : #324

## Changes 📝
- Next.js의 default 서버 fetch caching 전략: 'force-cache' 이여서, 동호회 소개 페이지에서 렌더링 버벅이는 현상이 발생했습니다. 
  - restClient에서 get 요청의 header에 `cache: "no-store"` 설정을 해두었습니다.
- 동호회 소개 페이지는 ssr을 적용하였습니다. ssr 적용을 했기 때문에 서버 컴포넌트에서 fetch 하는데, 서버 컴포넌트에서 fech 성공 후 페이지를 렌더링했음에도 불구하고 클라이언트 컴포넌트에서도 fetch를 시도했습니다. 
  - stale time을 적용함으로써 이 현상을 해결하였습니다. 

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
###  stale time 해결 방법은 이해를 완벽하게 한 상태에서 해결한 상황이 아닙니다. 좀 더 찾아봐야 합니다
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
