### PR TITLE
fix: 이미지 fetch 결과를 request body에 넣기

### DIFF
--- a/components/club/ClubForm.tsx
+++ b/components/club/ClubForm.tsx
@@ -149,7 +149,7 @@ function ClubForm(props: ClubFormProps) {
     const newClubData: ClubForm = {
       club_name: data.club_name,
       club_description: data.club_description,
-      club_image: imgUrl,
+      club_image: data.club_image,
     };
 
     if (initialData) return patchClub(newClubData);

--- a/components/pages/myPage/EditProfileDialog.tsx
+++ b/components/pages/myPage/EditProfileDialog.tsx
@@ -114,7 +114,7 @@ function EditProfileDialog({
     } else {
       putProfile({
         name,
-        profile_image_url: profileImage,
+        profile_image_url: data.profileImage,
       });
     }
   };

--- a/lib/api/hooks/clubHook.ts
+++ b/lib/api/hooks/clubHook.ts
@@ -82,11 +82,10 @@ export const usePostClubs = (onSuccess: (clubToken: string) => void) => {
 };
 
 export const usePostClubsImg = () => {
-  return useMutation({
-    mutationFn: (clubImg: FormData) => postClubsImg(clubImg),
-    onError: (error: Error) => alert(error),
-  });
+  const mutationFn = (clubImg: FormData) => postClubsImg(clubImg);
+  return useMutationWithToast(mutationFn);
 };
+
 export const useGetClubsById = (clubId: string) => {
   return useQueryWithToast<GetClubDetailData>(
     ["clubsDataById", clubId],

--- a/lib/api/hooks/clubHook.ts
+++ b/lib/api/hooks/clubHook.ts
@@ -82,8 +82,10 @@ export const usePostClubs = (onSuccess: (clubToken: string) => void) => {
 };
 
 export const usePostClubsImg = () => {
-  const mutationFn = (clubImg: FormData) => postClubsImg(clubImg);
-  return useMutationWithToast(mutationFn);
+  return useMutation({
+    mutationFn: (clubImg: FormData) => postClubsImg(clubImg),
+    onError: (error: Error) => alert(error),
+  });
 };
 
 export const useGetClubsById = (clubId: string) => {

--- a/lib/api/hooks/memberHook.ts
+++ b/lib/api/hooks/memberHook.ts
@@ -1,11 +1,3 @@
-import type {
-  GetMemberMachesRecordData,
-  GetMemberMyClubsData,
-  GetMemberMyPageData,
-  PutMemberProfileData,
-  PutMemberProfileRequest,
-} from "@/types/memberTypes";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getMembersMatchesRecord,
   getMembersMyClubs,
@@ -13,9 +5,16 @@ import {
   getMembersSession,
   postMembersProfileImage,
   putMembersProfile,
-} from "../functions/memberFn";
-import useMutationWithToast from "./useMutationWithToast";
-import useQueryWithToast from "./useQueryWithToast";
+} from "@/lib/api/functions/memberFn";
+import useMutationWithToast from "@/lib/api/hooks/useMutationWithToast";
+import useQueryWithToast from "@/lib/api/hooks/useQueryWithToast";
+import type {
+  GetMemberMachesRecordData,
+  GetMemberMyPageData,
+  PutMemberProfileData,
+  PutMemberProfileRequest,
+} from "@/types/memberTypes";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useGetMembersSession = () => {
   return useQuery({


### PR DESCRIPTION
- Close #327

## What is this PR? 🔍

- 기능 : 이미지 fetch 결과를 request body에 넣기
- issue : #327

## Changes 📝
- 이미지 fetching된 결과를 최종적으로 fetch 해야하는 api의 body에 넣어 주었습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
에러 상황
![image](https://github.com/user-attachments/assets/013a957f-2735-415a-9562-2afc409787a0)

수정 상황
![image](https://github.com/user-attachments/assets/32018d01-d3e4-4dde-9e4b-5fd2446e6bcf)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
