### PR TITLE
feat: 검색어 제한두기 (50자)

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,7 +1,13 @@
+import Spinner from "@/components/Spinner";
 import SearchResult from "@/components/pages/club/SearchResult";
+import { Suspense } from "react";
 
 function Page() {
-  return <SearchResult />;
+  return (
+    <Suspense fallback={<Spinner />}>
+      <SearchResult />
+    </Suspense>
+  );
 }
 
 export default Page;

--- a/components/pages/club/SearchResult.tsx
+++ b/components/pages/club/SearchResult.tsx
@@ -27,10 +27,9 @@ function SearchResult() {
     return (
       <div className="flex flex-col justify-center items-center space-y-4 min-h-[50vh] gap-3">
         <SearchX className="h-14 w-14 text-gray-400" aria-hidden="true" />
-        <h2 className="text-xl font-medium text-gray-800">검색 결과 없음</h2>
-        <p className="text-base text-gray-600 text-center">
+        <h2 className="text-xl font-medium text-gray-800">
           검색은 50자 이내만 가능합니다
-        </p>
+        </h2>
         <p className="text-base text-gray-600 text-center">
           다른 검색어를 시도해보세요.
         </p>

--- a/components/pages/club/SearchResult.tsx
+++ b/components/pages/club/SearchResult.tsx
@@ -11,13 +11,32 @@ import React from "react";
 
 function SearchResult() {
   const searchParams = useSearchParams();
-  const query = searchParams.get("q") || "";
+  const query = searchParams.get("search") || "";
 
-  const { data, isLoading, fetchNextPage, hasNextPage } = useGetSearchClubs(
-    12,
-    "clubId",
-    query,
-  );
+  // 검색어 길이가 50자를 초과하는 경우 에러 처리
+  const isQueryValid = query.length <= 50;
+
+  const {
+    data = [],
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetSearchClubs(12, "clubId", isQueryValid ? query : "");
+
+  if (!isQueryValid) {
+    return (
+      <div className="flex flex-col justify-center items-center space-y-4 min-h-[50vh] gap-3">
+        <SearchX className="h-14 w-14 text-gray-400" aria-hidden="true" />
+        <h2 className="text-xl font-medium text-gray-800">검색 결과 없음</h2>
+        <p className="text-base text-gray-600 text-center">
+          검색은 50자 이내만 가능합니다
+        </p>
+        <p className="text-base text-gray-600 text-center">
+          다른 검색어를 시도해보세요.
+        </p>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -27,9 +46,9 @@ function SearchResult() {
     );
   }
 
-  if (data.length === 0) {
+  if (!data || data.length === 0) {
     return (
-      <div className="flex flex-col justify-center items-center space-y-4 min-h-[50vh]">
+      <div className="flex flex-col justify-center items-center space-y-4 min-h-[50vh] gap-3">
         <SearchX className="h-14 w-14 text-gray-400" aria-hidden="true" />
         <h2 className="text-xl font-medium text-gray-800">검색 결과 없음</h2>
         <p className="text-base text-gray-600 text-center">

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -5,7 +5,7 @@ import { usePostLogout } from "@/lib/api/hooks/SessionHook";
 import { useGetMembersSession } from "@/lib/api/hooks/memberHook";
 import { BadgeAlert, Search } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { useRef, useState } from "react";
 
@@ -22,12 +22,15 @@ function Header() {
   const { data, isLoading } = useGetMembersSession();
   const inputRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
+  const searchParams = useSearchParams();
+
+  const search = searchParams.get("search");
 
   const handleSearch = () => {
     if (inputRef.current) {
       const query = inputRef.current.value.replace(/\n/g, "").trim();
       if (query) {
-        router.push(`/search?q=${encodeURIComponent(query)}`);
+        router.push(`/search?search=${encodeURIComponent(query)}`);
       }
     }
   };
@@ -146,6 +149,7 @@ function Header() {
           <div className="relative flex-grow max-w-[400px]">
             <input
               ref={inputRef}
+              defaultValue={search || ""}
               type="text"
               placeholder="동호회 이름을 검색하세요"
               className="w-full h-10 pl-4 pr-12 text-sm outline-none border-none rounded-lg bg-gray-50 text-gray-500 focus-visible:ring-2 placeholder-transparent md:placeholder-gray-400"


### PR DESCRIPTION
- Close #329

## What is this PR? 🔍

- 기능 :검색어 제한두기
- issue : #329

## Changes 📝
- searchParams의 키값을 search로 변경하였습니다.
- 검색 결과는 suspense 컴포넌트로 묶어두었습니다
  - [[Next.js 공식문서](https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior)] We recommend wrapping the Client Component that uses useSearchParams in a <Suspense/> boundary. This will allow any Client Components above it to be statically rendered and sent as part of initial HTML. [Example](https://nextjs.org/docs/app/api-reference/functions/use-search-params#static-rendering). 
- 검색 결과는 50자 이내로 제한해두었습니다. 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/20293fe3-d2b5-46f5-ae5a-892e563533a2)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
