### PR TITLE
feat: optimistic update 적용하기

### DIFF
--- a/components/club/LeagueDetail/MatchButton.tsx
+++ b/components/club/LeagueDetail/MatchButton.tsx
@@ -10,7 +10,7 @@ import type { GetLeagueDetailData } from "@/types/leagueTypes";
 import type { GetMemberSessionData } from "@/types/memberTypes";
 import { BookUser } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 interface MatchButtonProps {
   clubId: string;
@@ -26,6 +26,7 @@ const MatchButton = ({
   loginedUser,
 }: MatchButtonProps) => {
   const router = useRouter();
+  const { matchId } = useParams();
 
   const matchCreateCondition =
     (league.league_status === "RECRUITING_COMPLETED" ||
@@ -37,8 +38,9 @@ const MatchButton = ({
   };
 
   const { mutate: createMatch } = usePostMatches(
-    clubId as string,
-    leagueId as string,
+    clubId,
+    leagueId,
+    matchId as string,
     () => createMatchOnSuccess(),
   );
 

--- a/components/club/ScoreBoard/PlayerScore.tsx
+++ b/components/club/ScoreBoard/PlayerScore.tsx
@@ -7,6 +7,7 @@ interface PlayerScoreProps {
   isEditing: boolean;
   inputRef: RefObject<HTMLInputElement>;
   onScoreUpdate: () => void;
+  onInputChange: (value: string) => void;
   disabled?: boolean;
 }
 
@@ -16,6 +17,7 @@ function PlayerScore({
   isEditing,
   inputRef,
   onScoreUpdate,
+  onInputChange,
   disabled = false,
 }: PlayerScoreProps) {
   return (
@@ -31,6 +33,10 @@ function PlayerScore({
           min={0}
           max={30}
           step={1}
+          onChange={(e) => {
+            const value = Math.max(0, Math.min(Number(e.target.value), 30)); // 값 제한
+            onInputChange(value.toString()); // 변경된 값 상위 컴포넌트로 전달
+          }}
           className="bg-black hover:bg-zinc-800 w-24 h-24 sm:w-32 sm:h-32 text-red-500 text-4xl sm:text-6xl text-center rounded-lg shadow-inner focus:ring-4 focus:ring-primary-400 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           disabled={disabled}
         />

--- a/components/club/ScoreBoard/PlayerScore.tsx
+++ b/components/club/ScoreBoard/PlayerScore.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@/components/ui/Button";
+import type { MatchParticipantType } from "@/types/matchTypes";
 import type { RefObject } from "react";
 
 interface PlayerScoreProps {
-  player: string;
+  players: MatchParticipantType[];
   score: number;
   isEditing: boolean;
   inputRef: RefObject<HTMLInputElement>;
@@ -12,7 +13,7 @@ interface PlayerScoreProps {
 }
 
 function PlayerScore({
-  player,
+  players,
   score,
   isEditing,
   inputRef,
@@ -22,9 +23,14 @@ function PlayerScore({
 }: PlayerScoreProps) {
   return (
     <div className="text-center space-y-4">
-      <h2 className="text-xl sm:text-2xl font-bold tracking-wide text-gray-100">
-        {player}
-      </h2>
+      {players?.map((player) => (
+        <h2
+          key={player.image}
+          className="text-lg sm:text-xl font-bold tracking-wide text-gray-100"
+        >
+          {player.name}
+        </h2>
+      ))}
       {isEditing ? (
         <input
           ref={inputRef}

--- a/components/club/ScoreBoard/index.tsx
+++ b/components/club/ScoreBoard/index.tsx
@@ -92,10 +92,10 @@ export default function Scoreboard(props: ScoreboardProps) {
   const debouncedUpdateScore = useDebouncedUpdateScore(patchSetScore);
 
   useEffect(() => {
-    if (scoreData?.data) {
+    if (scoreData) {
       setTempScore({
-        score1: scoreData.data.set_score1,
-        score2: scoreData.data.set_score2,
+        score1: scoreData.set_score1,
+        score2: scoreData.set_score2,
       });
     }
   }, [scoreData]);
@@ -150,8 +150,8 @@ export default function Scoreboard(props: ScoreboardProps) {
 
   const handleCancelEditing = () => {
     setTempScore({
-      score1: scoreData?.data?.set_score1 || 0,
-      score2: scoreData?.data?.set_score2 || 0,
+      score1: scoreData?.set_score1 || 0,
+      score2: scoreData?.set_score2 || 0,
     });
     setIsEditing(false);
   };

--- a/components/club/ScoreBoard/index.tsx
+++ b/components/club/ScoreBoard/index.tsx
@@ -170,6 +170,7 @@ export default function Scoreboard(props: ScoreboardProps) {
         matchStatus={matchStatus}
         postMatchStart={postMatchStart}
       />
+      <h3 className="text-lg">Set {currentSetNumber}</h3>
       <div className="grid grid-cols-2 gap-6 w-full">
         <PlayerScore
           players={player1}

--- a/components/club/ScoreBoard/index.tsx
+++ b/components/club/ScoreBoard/index.tsx
@@ -3,13 +3,18 @@
 import OverlayMessage from "@/components/club/ScoreBoard/OverlayMessage";
 import PlayerScore from "@/components/club/ScoreBoard/PlayerScore";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { postSetScore } from "@/lib/api/functions/matchFn";
 import {
   useGetSetScore,
   usePatchSetScore,
   usePostMatchStart,
   usePostSetScore,
 } from "@/lib/api/hooks/matchHook";
-import type { MatchStatusType } from "@/types/matchTypes";
+import type {
+  MatchStatusType,
+  PatchMatchSetScoreRequest,
+} from "@/types/matchTypes";
 import { Maximize2, Minimize2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -34,10 +39,14 @@ export default function Scoreboard(props: ScoreboardProps) {
     player2,
   } = props;
 
-  const [isEditing, setIsEditing] = useState(false);
+  const { toast } = useToast();
   const inputRefPlayer1 = useRef<HTMLInputElement>(null);
   const inputRefPlayer2 = useRef<HTMLInputElement>(null);
-  const scoreboardRef = useRef<HTMLDivElement | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [tempScore, setTempScore] = useState<PatchMatchSetScoreRequest>({
+    score1: 0,
+    score2: 0,
+  });
 
   const { data: scoreData, isLoading } = useGetSetScore(
     clubId,
@@ -53,21 +62,12 @@ export default function Scoreboard(props: ScoreboardProps) {
     matchId,
   );
 
-  const [score, setScore] = useState<{ score1: number; score2: number }>({
-    score1: 0,
-    score2: 0,
-  });
-
-  const [isFullscreen, setIsFullscreen] = useState(false);
-
-  useEffect(() => {
-    if (scoreData?.data) {
-      setScore({
-        score1: scoreData.data.set_score1,
-        score2: scoreData.data.set_score2,
-      });
-    }
-  }, [scoreData]);
+  const { mutate: patchSetScore } = usePatchSetScore(
+    clubId,
+    leagueId,
+    matchId,
+    currentSetNumber,
+  );
 
   const { mutate: postSetScore } = usePostSetScore(
     clubId,
@@ -76,139 +76,134 @@ export default function Scoreboard(props: ScoreboardProps) {
     currentSetNumber,
   );
 
-  const { mutate: patchSetScore, isPending } = usePatchSetScore(
-    clubId,
-    leagueId,
-    matchId,
-    currentSetNumber,
-  );
+  useEffect(() => {
+    if (scoreData?.data) {
+      setTempScore({
+        score1: scoreData.data.set_score1,
+        score2: scoreData.data.set_score2,
+      });
+    }
+  }, [scoreData]);
 
   const updateScore = (key: "score1" | "score2", increment: number) => {
-    if (isLoading || isPending) return;
+    if (isEditing) return;
+
+    const currentScore = tempScore[key];
+    if (currentScore >= 30 && increment > 0) {
+      toast({
+        title: "최대 점수 제한",
+        description: "점수는 30점을 초과할 수 없습니다.",
+        variant: "destructive",
+      });
+      return;
+    }
 
     const updatedScore = {
-      ...score,
-      [key]: Math.max(0, score[key] + increment),
+      ...tempScore,
+      [key]: Math.min(30, currentScore + increment),
     };
 
+    setTempScore(updatedScore);
     patchSetScore(updatedScore);
   };
 
-  const postNextSet = () => {
-    postSetScore(score);
+  const handleInputChange = (player: "score1" | "score2", value: string) => {
+    if (Number(value) >= 30) {
+      toast({
+        title: "최대 점수 제한",
+        description: "점수는 30점을 초과할 수 없습니다.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setTempScore((prev) => ({
+      ...prev,
+      [player]: Math.min(Math.max(Number(value), 0), 30),
+    }));
   };
 
   const handleSaveScores = () => {
-    const newPlayer1Score = inputRefPlayer1.current?.value || "0";
-    const newPlayer2Score = inputRefPlayer2.current?.value || "0";
-
-    const updatedScore = {
-      score1: Math.min(Math.max(Number(newPlayer1Score), 0), 30),
-      score2: Math.min(Math.max(Number(newPlayer2Score), 0), 30),
-    };
-
-    // setScore(updatedScore);
-    patchSetScore(updatedScore);
+    patchSetScore(tempScore);
     setIsEditing(false);
   };
 
-  const toggleFullscreen = () => {
-    if (document.fullscreenElement) {
-      document.exitFullscreen();
-    } else {
-      scoreboardRef.current?.requestFullscreen();
-    }
+  const handleCancelEditing = () => {
+    setTempScore({
+      score1: scoreData?.data?.set_score1 || 0,
+      score2: scoreData?.data?.set_score2 || 0,
+    });
+    setIsEditing(false);
   };
 
-  useEffect(() => {
-    if (isEditing) {
-      inputRefPlayer1.current?.focus();
-    }
-
-    const handleFullscreenChange = () => {
-      setIsFullscreen(!!document.fullscreenElement);
-    };
-
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    return () =>
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-  }, [isEditing]);
-
+  const postNextSet = () => {
+    postSetScore(tempScore);
+  };
   if (isLoading) {
     return <Skeleton className="w-full h-[450px] rounded-md" />;
   }
 
   return (
-    <div
-      ref={scoreboardRef}
-      className="bg-gradient-to-br from-gray-800 to-gray-900 flex flex-col items-center justify-center text-white shadow-2xl rounded-lg p-6 space-y-6 relative transition-all duration-300"
-    >
+    <div className="bg-gradient-to-br from-gray-800 to-gray-900 flex flex-col items-center justify-center text-white shadow-2xl rounded-lg p-6 space-y-6 relative transition-all duration-300">
       <OverlayMessage
         matchStatus={matchStatus}
         postMatchStart={postMatchStart}
       />
-      <>
-        <button
-          type="button"
-          onClick={toggleFullscreen}
-          className="absolute top-4 right-4 bg-none hover:bg-none text-whiterounded-lg hover:scale-105"
-        >
-          {isFullscreen ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
-        </button>
-
-        <div className="text-2xl font-extrabold tracking-wide text-gray-200">
-          Set {currentSetNumber}
-        </div>
-        <div className="grid grid-cols-2 gap-6 w-full">
-          <PlayerScore
-            player={player1}
-            score={score.score1}
-            isEditing={isEditing}
-            inputRef={inputRefPlayer1}
-            onScoreUpdate={() => updateScore("score1", 1)}
-            disabled={isLoading || isPending}
-          />
-          <PlayerScore
-            player={player2}
-            score={score.score2}
-            isEditing={isEditing}
-            inputRef={inputRefPlayer2}
-            onScoreUpdate={() => updateScore("score2", 1)}
-            disabled={isLoading || isPending}
-          />
-        </div>
-
-        {!isFullscreen && (
-          <div className="flex justify-center space-x-8 mt-4 gap-6">
-            {isEditing ? (
-              <button
-                type="button"
-                onClick={handleSaveScores}
-                className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg text-sm font-semibold shadow transition-all transform hover:scale-105"
-              >
-                저장
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => setIsEditing(true)}
-                className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg text-sm font-semibold shadow transition-all transform hover:scale-105"
-              >
-                수정
-              </button>
-            )}
-            {!isEditing && (
-              <button
-                type="button"
-                onClick={postNextSet}
-                className="bg-green-600 hover:bg-green-500 text-white px-4 py-2 rounded-lg text-sm font-semibold shadow transition-all transform hover:scale-105"
-              >
-                세트 종료
-              </button>
-            )}
-          </div>
+      <div className="grid grid-cols-2 gap-6 w-full">
+        <PlayerScore
+          player={player1}
+          score={tempScore.score1}
+          isEditing={isEditing}
+          inputRef={inputRefPlayer1}
+          onInputChange={(value) => handleInputChange("score1", value)}
+          onScoreUpdate={() => updateScore("score1", 1)}
+        />
+        <PlayerScore
+          player={player2}
+          score={tempScore.score2}
+          isEditing={isEditing}
+          inputRef={inputRefPlayer2}
+          onInputChange={(value) => handleInputChange("score2", value)}
+          onScoreUpdate={() => updateScore("score2", 1)}
+        />
+      </div>
+      <div className="flex justify-center space-x-4 mt-6 gap-2">
+        {isEditing ? (
+          <>
+            <button
+              type="button"
+              onClick={handleSaveScores}
+              className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg shadow transition-all"
+            >
+              저장
+            </button>
+            <button
+              type="button"
+              onClick={handleCancelEditing}
+              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg shadow transition-all"
+            >
+              취소
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsEditing(true)}
+            className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg shadow transition-all"
+          >
+            수정
+          </button>
         )}
-      </>
+
+        {!isEditing && (
+          <button
+            type="button"
+            onClick={postNextSet}
+            className="bg-green-600 hover:bg-green-500 text-white px-4 py-2 rounded-lg text-sm font-semibold shadow transition-all transform hover:scale-105"
+          >
+            세트 종료
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/club/ScoreBoard/index.tsx
+++ b/components/club/ScoreBoard/index.tsx
@@ -11,6 +11,7 @@ import {
   usePostSetScore,
 } from "@/lib/api/hooks/matchHook";
 import type {
+  MatchParticipantType,
   MatchStatusType,
   PatchMatchSetScoreRequest,
 } from "@/types/matchTypes";
@@ -23,8 +24,8 @@ interface ScoreboardProps {
   matchId: string;
   currentSetNumber: number;
   matchStatus: MatchStatusType;
-  player1: string;
-  player2: string;
+  player1: MatchParticipantType[];
+  player2: MatchParticipantType[];
 }
 
 // 디바운스된 점수 업데이트 함수를 생성하는 훅
@@ -171,7 +172,7 @@ export default function Scoreboard(props: ScoreboardProps) {
       />
       <div className="grid grid-cols-2 gap-6 w-full">
         <PlayerScore
-          player={player1}
+          players={player1}
           score={tempScore.score1}
           isEditing={isEditing}
           inputRef={inputRefPlayer1}
@@ -179,7 +180,7 @@ export default function Scoreboard(props: ScoreboardProps) {
           onScoreUpdate={() => updateScore("score1", 1)}
         />
         <PlayerScore
-          player={player2}
+          players={player2}
           score={tempScore.score2}
           isEditing={isEditing}
           inputRef={inputRefPlayer2}

--- a/components/pages/club/MatchDetailPage.tsx
+++ b/components/pages/club/MatchDetailPage.tsx
@@ -79,8 +79,8 @@ export default function MatchDetailPage() {
               matchId={matchId as string}
               currentSetNumber={setDetail?.set_number_in_progress}
               matchStatus={matchStatus as MatchStatusType}
-              player1={participants1[0]?.name || "Player 1"}
-              player2={participants2[0]?.name || "Player 2"}
+              player1={participants1?.filter((p) => p !== undefined) || []}
+              player2={participants2?.filter((p) => p !== undefined) || []}
             />
           </CardContent>
         </Card>

--- a/components/pages/club/MatchDetailPage.tsx
+++ b/components/pages/club/MatchDetailPage.tsx
@@ -5,7 +5,7 @@ import MatchDetail from "@/components/club/MatchDetail";
 import Scoreboard from "@/components/club/ScoreBoard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useGetSetsDetail } from "@/lib/api/hooks/matchHook";
-import type { MatchParticipantType, MatchStatusType } from "@/types/matchTypes";
+import type { MatchStatusType } from "@/types/matchTypes";
 import { RadioTower, Trophy } from "lucide-react";
 import { useParams } from "next/navigation";
 

--- a/lib/api/hooks/matchHook.ts
+++ b/lib/api/hooks/matchHook.ts
@@ -13,7 +13,6 @@ import type {
   GetMatchesData,
   GetSetsDetailData,
   MatchStatusType,
-  PatchMatchSetScoreData,
   PatchMatchSetScoreRequest,
   PatchMatchSetScoreResponse,
   PostMatchSetScoreData,

--- a/lib/api/hooks/matchHook.ts
+++ b/lib/api/hooks/matchHook.ts
@@ -11,6 +11,7 @@ import {
 import useQueryWithToast from "@/lib/api/hooks/useQueryWithToast";
 import type {
   GetMatchesData,
+  GetSetScoreData,
   GetSetsDetailData,
   MatchStatusType,
   PatchMatchSetScoreRequest,
@@ -20,7 +21,7 @@ import type {
   PostMatchStartData,
   PostMatchesData,
 } from "@/types/matchTypes";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import useMutationWithToast from "./useMutationWithToast";
 
 export const useGetMatches = (clubId: string, leagueId: string) => {
@@ -47,12 +48,14 @@ export const useGetSetScore = (
   setNumber: number,
   matchStatus: MatchStatusType,
 ) => {
-  return useQuery({
-    queryKey: ["matchDetail", leagueId, matchId, setNumber],
-    queryFn: () => getSetScore(clubId, leagueId, matchId, setNumber),
-    enabled: !(matchStatus !== "IN_PROGRESS"),
-    refetchInterval: 5000, // 5초마다 재요청
-  });
+  return useQueryWithToast<GetSetScoreData>(
+    ["matchDetail", leagueId, matchId, String(setNumber)],
+    () => getSetScore(clubId, leagueId, matchId, setNumber),
+    {
+      enabled: !(matchStatus !== "IN_PROGRESS"),
+      refetchInterval: 5000, // 5초마다 재요청
+    },
+  );
 };
 
 export const usePostMatches = (

--- a/lib/api/hooks/matchHook.ts
+++ b/lib/api/hooks/matchHook.ts
@@ -38,6 +38,7 @@ export const useGetSetsDetail = (
   return useQueryWithToast<GetSetsDetailData>(
     ["matchesData", clubId, leagueId, matchId],
     () => getSetsDetail(clubId, leagueId, matchId),
+    { refetchInterval: 5000 },
   );
 };
 
@@ -53,7 +54,7 @@ export const useGetSetScore = (
     () => getSetScore(clubId, leagueId, matchId, setNumber),
     {
       enabled: !(matchStatus !== "IN_PROGRESS"),
-      refetchInterval: 5000, // 5초마다 재요청
+      refetchInterval: 3000, // 3초마다 재요청
     },
   );
 };

--- a/lib/api/hooks/matchHook.ts
+++ b/lib/api/hooks/matchHook.ts
@@ -1,3 +1,4 @@
+import { toast, useToast } from "@/hooks/use-toast";
 import {
   getMatches,
   getSetScore,
@@ -20,7 +21,7 @@ import type {
   PostMatchStartData,
   PostMatchesData,
 } from "@/types/matchTypes";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import useMutationWithToast from "./useMutationWithToast";
 
 export const useGetMatches = (clubId: string, leagueId: string) => {
@@ -48,7 +49,7 @@ export const useGetSetScore = (
   matchStatus: MatchStatusType,
 ) => {
   return useQuery({
-    queryKey: ["matchDetail", leagueId, matchId, setNumber, matchStatus],
+    queryKey: ["matchDetail", leagueId, matchId, setNumber],
     queryFn: () => getSetScore(clubId, leagueId, matchId, setNumber),
     enabled: !(matchStatus !== "IN_PROGRESS"),
     refetchInterval: 5000, // 5초마다 재요청
@@ -58,6 +59,7 @@ export const useGetSetScore = (
 export const usePostMatches = (
   clubId: string,
   leagueId: string,
+  matchId: string,
   onSuccess: () => void,
 ) => {
   const queryClient = useQueryClient();
@@ -65,7 +67,9 @@ export const usePostMatches = (
   const mutationFn = () => postMatches(clubId, leagueId);
 
   const onSuccessCallback = () => {
-    queryClient.invalidateQueries({ queryKey: ["matchesData"] });
+    queryClient.invalidateQueries({
+      queryKey: ["matchesData", clubId, leagueId, matchId],
+    });
     queryClient.invalidateQueries({ queryKey: ["leagueDetails", leagueId] });
     onSuccess();
   };
@@ -129,17 +133,59 @@ export const usePatchSetScore = (
 ) => {
   const queryClient = useQueryClient();
 
-  const mutationFn = (score: PatchMatchSetScoreRequest) =>
-    patchSetScore(score, clubId, leagueId, matchId, setNumber);
+  return useMutation<
+    PatchMatchSetScoreResponse,
+    Error,
+    PatchMatchSetScoreRequest,
+    { previousMatchData?: PatchMatchSetScoreRequest }
+  >({
+    mutationFn: (score: PatchMatchSetScoreRequest) =>
+      patchSetScore(score, clubId, leagueId, matchId, setNumber),
+    onMutate: async (score) => {
+      const previousMatchData =
+        queryClient.getQueryData<PatchMatchSetScoreRequest>([
+          "matchesData",
+          clubId,
+          leagueId,
+          matchId,
+        ]);
 
-  const onSuccessCallback = () => {
-    queryClient.invalidateQueries({
-      queryKey: ["matchesData", clubId, leagueId, matchId],
-    });
-    queryClient.invalidateQueries({ queryKey: ["leagueDetails", leagueId] });
-  };
-  return useMutationWithToast<
-    PatchMatchSetScoreData,
-    PatchMatchSetScoreRequest
-  >(mutationFn, onSuccessCallback);
+      // 낙관적 업데이트
+      queryClient.setQueryData(
+        ["matchesData", clubId, leagueId, matchId],
+        (oldData: PatchMatchSetScoreRequest | undefined) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            ...score, // 새로운 점수로 덮어쓰기
+          };
+        },
+      );
+
+      return { previousMatchData }; // 롤백을 위해 이전 데이터 반환
+    },
+    onError: (err, score, context) => {
+      const { toast } = useToast();
+      toast({
+        title: "점수 등록 실패",
+        description: "점수 등록에 실패하였습니다",
+        variant: "destructive",
+      });
+
+      if (context?.previousMatchData) {
+        // 롤백
+        queryClient.setQueryData(
+          ["matchesData", clubId, leagueId, matchId],
+          context.previousMatchData,
+        );
+      }
+    },
+    onSettled: () => {
+      // 서버와 동기화
+      queryClient.invalidateQueries({
+        queryKey: ["matchesData", clubId, leagueId, matchId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["leagueDetails", leagueId] });
+    },
+  });
 };

--- a/lib/api/hooks/useMutationWithToast.ts
+++ b/lib/api/hooks/useMutationWithToast.ts
@@ -1,8 +1,8 @@
 "use client";
 import { useToast } from "@/hooks/use-toast";
 import type { ErrorCode } from "@/types/errorCode";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
 
 interface CommonResponse<T> {
   result?: "SUCCESS" | "FAIL";


### PR DESCRIPTION
- Close #335 

## What is this PR? 🔍

- 기능 : 낙관적 업데이트 적용
- issue : #335

## Changes 📝
- 점수판 업데이트가 제대로 안이루어지는 것을 optimistic update로 전환하여 점수가 항상 올라가는 것 처럼 보이게 했습니다. 
- 사용자 클릭이 많아지는 경우를 대비하여 debounce를 적용하였습니다. 0.3초 단위
- 점수 등록에 toast 훅을 적용하였습니다
- set 변경, 매치 시작을 감지하기 위해 set detail도 폴링으로 구현하였습니다
- 
- 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
[이전]

https://github.com/user-attachments/assets/86db517d-faed-481a-810d-e7aecaa4e195


[이후]

https://github.com/user-attachments/assets/9491b8f6-75f4-4241-8ad0-ad99f97a51f5

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
